### PR TITLE
FIX: forceInitialHand not work after changeIdol

### DIFF
--- a/packages/gakumas-engine/engine/TurnManager.js
+++ b/packages/gakumas-engine/engine/TurnManager.js
@@ -62,7 +62,7 @@ export default class TurnManager extends EngineComponent {
     return [firstTurn, ...randomTurns, ...lastThreeTurns];
   }
 
-  startTurn(state) {
+  startTurn(state, forceInitialHand = false) {
     this.logger.debug("Starting turn", state[S.turnsElapsed] + 1);
 
     this.logger.log(state, "startTurn", {
@@ -87,7 +87,7 @@ export default class TurnManager extends EngineComponent {
     }
 
     // Add forced initial hand cards
-    if (state[S.turnsElapsed] == 0) {
+    if (state[S.turnsElapsed] == 0 || forceInitialHand) {
       for (let i = 0; i < 2; i++) {
         const card = this.engine.cardManager.peekDeck(state);
         if (
@@ -142,6 +142,7 @@ export default class TurnManager extends EngineComponent {
 
     // Start next turn
     if (state[S.turnsRemaining] > 0) {
+      let forceInitialHand = false;
       const stageConfig = this.getConfig(state).stage;
       if (stageConfig.type === "linkContest") {
         const { linkPhaseChangeTurns } = stageConfig;
@@ -151,12 +152,13 @@ export default class TurnManager extends EngineComponent {
             i < this.engine.linkConfigs.length - 1
           ) {
             this.engine.changeIdol(state);
+            forceInitialHand = true;
             break;
           }
         }
       }
 
-      this.startTurn(state);
+      this.startTurn(state, forceInitialHand);
     }
   }
 }


### PR DESCRIPTION
![Screenshot01434](https://github.com/user-attachments/assets/f3ae39e5-e48b-488b-8f6a-5fedebfbacea)
<img width="404" height="402" alt="turn5" src="https://github.com/user-attachments/assets/e7c95819-b25a-4a36-96d8-6b9f9504075e" />
<img width="401" height="402" alt="turn6" src="https://github.com/user-attachments/assets/a5dae10b-31af-46ab-a26a-b0f2bc564ea9" />
リンクコンテストのMID、EDのアイドルへの切り替わり時にも前夜、意思などのステージ開始時手札に入るスキルカードは切り替え後最初のターンの手札に5枚まで追加でドローされますが、現在のシミュではそうなっていないようです。

修正案を送るので何らかの方法で対応をお願いします。