### PR TITLE
Increase param upper limit from 2760 to 3360 for seasons >= 37

### DIFF
--- a/packages/gakumas-engine/config/IdolStageConfig.js
+++ b/packages/gakumas-engine/config/IdolStageConfig.js
@@ -50,8 +50,10 @@ export default class IdolStageConfig {
         param = Math.min(param, 2160);
       } else if (season < 25) {
         param = Math.min(param, 2400);
-      } else {
+      } else if (season < 37) {
         param = Math.min(param, 2760);
+      } else {
+        param = Math.min(param, 3360);
       }
       const criterion = criteria[key];
 


### PR DESCRIPTION
Increased the upper limit of `param` from 2760 to 3360 for seasons >= 37.