### PR TITLE
harden: add path validation in csv_to_json.py...

### DIFF
--- a/packages/gakumas-data/scripts/csv_to_json.py
+++ b/packages/gakumas-data/scripts/csv_to_json.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import os
 
 data_types = [
     "idols",
@@ -11,10 +12,17 @@ data_types = [
     "p_drinks",
 ]
 
+csv_dir = os.path.realpath("csv")
+json_dir = os.path.realpath("json")
+
 for data_type in data_types:
     data = []
 
-    with open(f"csv/{data_type}.csv", encoding="utf-8") as f:
+    csv_path = os.path.realpath(os.path.join("csv", f"{data_type}.csv"))
+    if not csv_path.startswith(csv_dir + os.sep):
+        raise ValueError(f"Invalid data_type: {data_type}")
+
+    with open(csv_path, encoding="utf-8") as f:
         csv_reader = csv.DictReader(f)
         for row in csv_reader:
             for k, v in row.items():
@@ -24,5 +32,9 @@ for data_type in data_types:
                     row[k] = int(v)
             data.append(row)
 
-    with open(f"json/{data_type}.json", "w", encoding="utf-8") as f:
+    json_path = os.path.realpath(os.path.join("json", f"{data_type}.json"))
+    if not json_path.startswith(json_dir + os.sep):
+        raise ValueError(f"Invalid data_type: {data_type}")
+
+    with open(json_path, "w", encoding="utf-8") as f:
         f.write(json.dumps(data, ensure_ascii=False, separators=(",", ":")))


### PR DESCRIPTION
## Summary
Harden input handling in `packages/gakumas-data/scripts/csv_to_json.py` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | utils.custom.path-traversal-open |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `utils.custom.path-traversal-open` |
| **File** | `packages/gakumas-data/scripts/csv_to_json.py:17` |
| **Assessment** | Defensive hardening |

**Description**: User-controlled input used in file path for open() without sanitization. This can allow path traversal attacks to read arbitrary files.


## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `packages/gakumas-data/scripts/csv_to_json.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
