### PR TITLE
Fix duplicate memories created by repeated saves

### DIFF
--- a/gakumas-tools/app/api/memory/[id]/route.js
+++ b/gakumas-tools/app/api/memory/[id]/route.js
@@ -15,7 +15,7 @@ export async function PUT(request, { params: routeParams }) {
     await request.json();
 
   const { db } = await connect();
-  const { updatedId } = await db.collection("memories").updateOne(
+  await db.collection("memories").updateOne(
     { _id: id, userId },
     {
       $set: {
@@ -30,5 +30,5 @@ export async function PUT(request, { params: routeParams }) {
     }
   );
 
-  return Response.json({ id: updatedId });
+  return Response.json({ id });
 }

--- a/gakumas-tools/app/api/memory/bulk_delete/route.js
+++ b/gakumas-tools/app/api/memory/bulk_delete/route.js
@@ -13,9 +13,9 @@ export async function POST(request) {
   const { ids } = await request.json();
 
   const { db } = await connect();
-  const { deletedIds } = await db
+  const { deletedCount } = await db
     .collection("memories")
     .deleteMany({ userId, _id: { $in: ids.map((id) => new ObjectId(id)) } });
 
-  return Response.json({ ids: deletedIds });
+  return Response.json({ deletedCount });
 }

--- a/gakumas-tools/app/api/memory/route.js
+++ b/gakumas-tools/app/api/memory/route.js
@@ -40,5 +40,5 @@ export async function POST(request) {
     )
   );
 
-  return Response.json({ ids: insertedIds });
+  return Response.json({ ids: Object.values(insertedIds) });
 }

--- a/gakumas-tools/contexts/MemoryContext.js
+++ b/gakumas-tools/contexts/MemoryContext.js
@@ -50,8 +50,8 @@ export function MemoryContextProvider({ children }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ memories: [memory] }),
       });
-      const data = await result.json();
-      setId(data.id);
+      const { ids } = await result.json();
+      setId(ids[0]);
       setSaveState("saved");
     } else {
       await fetch(`/api/memory/${id}`, {


### PR DESCRIPTION
## Problem
`POST /api/memory` returns `insertMany`'s `insertedIds`, which is an index→id map (`{ "0": ObjectId }`), but `MemoryContext.save` reads `data.id` from the response. A newly created memory therefore never learns its own id:

- Pressing **Save** a second time (e.g. after fixing a typo in the name) takes the `!id` branch and inserts another copy instead of updating.
- **Save as new** never appears for a memory that was just created, because it is gated on `id`.

## Fix
- `POST /api/memory` now returns `{ ids: [...] }` as a plain array; the client reads `ids[0]`.
- `PUT /api/memory/[id]` and `POST /api/memory/bulk_delete` destructured `updatedId` / `deletedIds`, which don't exist on the driver's `UpdateResult` / `DeleteResult`, so both always responded with `{}`. They now return `{ id }` and `{ deletedCount }`.

No other callers read these responses (`uploadMemories` and `deleteMemories` ignore the body), so the shape changes are safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn