### PR TITLE
Surface memory API errors instead of hanging the UI

### DIFF
--- a/gakumas-tools/components/Memories/Memories.js
+++ b/gakumas-tools/components/Memories/Memories.js
@@ -1,6 +1,9 @@
 "use client";
 import { memo, useContext, useEffect, useMemo, useState } from "react";
 import { useSession } from "next-auth/react";
+import { useTranslations } from "next-intl";
+import Alert from "@/components/Alert";
+import Button from "@/components/Button";
 import DataContext from "@/contexts/DataContext";
 import SearchContext from "@/contexts/SearchContext";
 import { calculateContestPower } from "@/utils/contestPower";
@@ -14,8 +17,9 @@ import MemoriesList from "./MemoriesList";
 import styles from "./Memories.module.scss";
 
 function Memories() {
+  const t = useTranslations("Memories");
   const { status } = useSession();
-  const { memories, fetchMemories } = useContext(DataContext);
+  const { memories, memoriesError, fetchMemories } = useContext(DataContext);
   const { pItemIds, skillCardIds } = useContext(SearchContext);
   const [action, setAction] = useState(null);
   const [selectedMemories, setSelectedMemories] = useState({});
@@ -58,6 +62,18 @@ function Memories() {
         selectedMemories={selectedMemories}
         setSelectedMemories={setSelectedMemories}
       />
+      {memoriesError && (
+        <Alert variant="danger" className={styles.alert}>
+          <div className={styles.alertContent}>
+            {t(`${memoriesError}Error`)}
+            {memoriesError == "load" && (
+              <Button size="sm" onClick={fetchMemories}>
+                {t("retry")}
+              </Button>
+            )}
+          </div>
+        </Alert>
+      )}
       <MemoriesList
         memories={filteredMemories}
         deleting={action == "delete"}

--- a/gakumas-tools/components/Memories/Memories.module.scss
+++ b/gakumas-tools/components/Memories/Memories.module.scss
@@ -20,6 +20,17 @@
   padding: tokens.$space-6;
 }
 
+.alert {
+  margin: tokens.$space-2 tokens.$space-3 0;
+}
+
+.alertContent {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: tokens.$space-2;
+}
+
 .header {
   display: flex;
   flex-direction: row;

--- a/gakumas-tools/components/MemorySave/MemorySave.js
+++ b/gakumas-tools/components/MemorySave/MemorySave.js
@@ -42,6 +42,11 @@ function MemorySave() {
       )}
 
       {saveState == "saved" && <FaCheck />}
+      {saveState == "error" && (
+        <span className={styles.error} role="alert">
+          {t("saveFailed")}
+        </span>
+      )}
     </div>
   );
 }

--- a/gakumas-tools/components/MemorySave/MemorySave.module.scss
+++ b/gakumas-tools/components/MemorySave/MemorySave.module.scss
@@ -1,7 +1,15 @@
+@use "../../styles/colors";
+@use "../../styles/tokens";
+
 .save {
   max-width: 400px;
   display: flex;
   align-items: center;
   gap: 8px;
   margin-top: 16px;
+}
+
+.error {
+  color: colors.$red;
+  font-size: tokens.$text-sm;
 }

--- a/gakumas-tools/contexts/DataContext.js
+++ b/gakumas-tools/contexts/DataContext.js
@@ -4,39 +4,67 @@ import { useSession } from "next-auth/react";
 
 const DataContext = createContext();
 
+async function request(url, options) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    throw new Error(
+      `${options?.method || "GET"} ${url} failed with ${response.status}`
+    );
+  }
+  return response;
+}
+
+function postJson(url, body) {
+  return request(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 export function DataContextProvider({ children }) {
   const { status } = useSession();
   const [memories, setMemories] = useState([]);
   const [memoriesLoading, setMemoriesLoading] = useState(false);
+  // One of "load" | "upload" | "delete" when the last request failed.
+  const [memoriesError, setMemoriesError] = useState(null);
 
   async function fetchMemories() {
-    if (status == "authenticated" && !memoriesLoading) {
-      setMemoriesLoading(true);
-      const response = await fetch("/api/memory");
+    if (status != "authenticated" || memoriesLoading) return;
+    setMemoriesLoading(true);
+    setMemoriesError(null);
+    try {
+      const response = await request("/api/memory");
       const data = await response.json();
       setMemories(data.memories);
+    } catch (error) {
+      console.error(error);
+      setMemoriesError("load");
+    } finally {
       setMemoriesLoading(false);
     }
   }
 
-  async function uploadMemories(memories) {
-    await fetch("/api/memory", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ memories }),
-    });
-
+  async function mutateMemories(action, url, body) {
+    setMemoriesError(null);
+    try {
+      await postJson(url, body);
+    } catch (error) {
+      console.error(error);
+      setMemoriesError(action);
+      return;
+    }
     fetchMemories();
   }
 
-  async function deleteMemories(memoryIds) {
-    await fetch("/api/memory/bulk_delete", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ids: memoryIds }),
-    });
+  function uploadMemories(memories) {
+    return mutateMemories("upload", "/api/memory", { memories });
+  }
 
-    fetchMemories();
+  function deleteMemories(memoryIds) {
+    return mutateMemories("delete", "/api/memory/bulk_delete", {
+      ids: memoryIds,
+    });
   }
 
   return (
@@ -47,6 +75,7 @@ export function DataContextProvider({ children }) {
         uploadMemories,
         deleteMemories,
         memoriesLoading,
+        memoriesError,
       }}
     >
       {children}

--- a/gakumas-tools/contexts/MemoryContext.js
+++ b/gakumas-tools/contexts/MemoryContext.js
@@ -44,22 +44,28 @@ export function MemoryContextProvider({ children }) {
       skillCardIds,
       customizations,
     };
-    if (asNew || !id) {
-      const result = await fetch("/api/memory", {
-        method: "POST",
+    const isNew = asNew || !id;
+    const url = isNew ? "/api/memory" : `/api/memory/${id}`;
+    const method = isNew ? "POST" : "PUT";
+    const body = isNew ? { memories: [memory] } : memory;
+    try {
+      const response = await fetch(url, {
+        method,
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ memories: [memory] }),
+        body: JSON.stringify(body),
       });
-      const { ids } = await result.json();
-      setId(ids[0]);
+      if (!response.ok) {
+        throw new Error(`${method} ${url} failed with ${response.status}`);
+      }
+      if (isNew) {
+        const { ids } = await response.json();
+        setId(ids[0]);
+      }
       setSaveState("saved");
-    } else {
-      await fetch(`/api/memory/${id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(memory),
-      });
-      setSaveState("saved");
+    } catch (error) {
+      console.error(error);
+      setSaveState("error");
+      return;
     }
     fetchMemories();
   }

--- a/gakumas-tools/messages/en.json
+++ b/gakumas-tools/messages/en.json
@@ -331,7 +331,8 @@
   "MemorySave": {
     "save": "Save",
     "saveAsNew": "Save as new",
-    "signInToSave": "Sign in with Discord to save"
+    "signInToSave": "Sign in with Discord to save",
+    "saveFailed": "Save failed"
   },
   "MemoriesNudge": {
     "create": "Create a memory",
@@ -340,6 +341,12 @@
   "MemoriesHeader": {
     "selected": "{num} memories selected",
     "delete": "Delete"
+  },
+  "Memories": {
+    "loadError": "Failed to load memories",
+    "uploadError": "Failed to save memories",
+    "deleteError": "Failed to delete memories",
+    "retry": "Retry"
   },
   "MemoryImporterModal": {
     "importMemories": "Import memories from screenshots",

--- a/gakumas-tools/messages/ja.json
+++ b/gakumas-tools/messages/ja.json
@@ -343,11 +343,18 @@
   "MemorySave": {
     "save": "保存",
     "saveAsNew": "新規保存",
-    "signInToSave": "Discordでログインして保存"
+    "signInToSave": "Discordでログインして保存",
+    "saveFailed": "保存に失敗しました"
   },
   "MemoriesHeader": {
     "selected": "{num}個のメモリーを選択",
     "delete": "削除する"
+  },
+  "Memories": {
+    "loadError": "メモリーの読み込みに失敗しました",
+    "uploadError": "メモリーの保存に失敗しました",
+    "deleteError": "メモリーの削除に失敗しました",
+    "retry": "再試行"
   },
   "MemoryImporterModal": {
     "importMemories": "Import memories from screenshots",

--- a/gakumas-tools/messages/ko.json
+++ b/gakumas-tools/messages/ko.json
@@ -335,11 +335,18 @@
   "MemorySave": {
     "save": "저장",
     "saveAsNew": "새로 저장",
-    "signInToSave": "Discord로 로그인하여 저장"
+    "signInToSave": "Discord로 로그인하여 저장",
+    "saveFailed": "저장에 실패했습니다"
   },
   "MemoriesHeader": {
     "selected": "{num}개의 메모리 선택됨",
     "delete": "삭제하기"
+  },
+  "Memories": {
+    "loadError": "메모리를 불러오지 못했습니다",
+    "uploadError": "메모리를 저장하지 못했습니다",
+    "deleteError": "메모리를 삭제하지 못했습니다",
+    "retry": "다시 시도"
   },
   "MemoryImporterModal": {
     "importMemories": "스크린샷으로부터 메모리 불러오기",

--- a/gakumas-tools/messages/zh-Hans.json
+++ b/gakumas-tools/messages/zh-Hans.json
@@ -331,7 +331,8 @@
   "MemorySave": {
     "save": "保存",
     "saveAsNew": "作为新回忆卡保存",
-    "signInToSave": "登入 Discord 以同步保存"
+    "signInToSave": "登入 Discord 以同步保存",
+    "saveFailed": "保存失败"
   },
   "MemoriesNudge": {
     "create": "创建回忆卡",
@@ -340,6 +341,12 @@
   "MemoriesHeader": {
     "selected": "{num} 个回忆卡被选中",
     "delete": "删除"
+  },
+  "Memories": {
+    "loadError": "回忆卡加载失败",
+    "uploadError": "回忆卡保存失败",
+    "deleteError": "回忆卡删除失败",
+    "retry": "重试"
   },
   "MemoryImporterModal": {
     "importMemories": "从截图中导入回忆卡",


### PR DESCRIPTION
Stacked on #111 (same `save` function in `MemoryContext`); GitHub will retarget this to `master` once that merges.

## Problem
`DataContext.fetchMemories/uploadMemories/deleteMemories` and `MemoryContext.save` never check `response.ok` and have no `try/catch`:

- A 401 (expired session) returns plain-text `Unauthorized`, so `response.json()` throws and `memoriesLoading` stays `true` forever. The memory count and import button are hidden while loading, so the page looks permanently empty until a reload.
- A failed save leaves `saveState` at `"saving"`, which keeps both Save buttons disabled; the only way out is to close and reopen the editor.
- Failed uploads/deletes are silent: the list simply doesn't change.

## Fix
- Loading/saving state is reset in `finally`; the failing request kind is recorded as `memoriesError` (`load` | `upload` | `delete`).
- The memories page shows an alert with the failure and a **Retry** button for loads.
- The memory editor shows an inline "Save failed" message (with `role="alert"`) when a save fails.
- New message keys (`Memories.*Error`, `Memories.retry`, `MemorySave.saveFailed`) added to all four locales.

Verified with a production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn