### PR TITLE
Confirm before bulk-deleting memories

### DIFF
--- a/gakumas-tools/components/Memories/MemoriesHeader.js
+++ b/gakumas-tools/components/Memories/MemoriesHeader.js
@@ -11,6 +11,7 @@ import {
   FaRegTrashCan,
 } from "react-icons/fa6";
 import Button from "@/components/Button";
+import ConfirmModal from "@/components/ConfirmModal";
 import IconButton from "@/components/IconButton";
 import MemoryEditorModal from "@/components/MemoryEditorModal";
 import StagePItems from "@/components/StagePItems";
@@ -108,10 +109,19 @@ function MemoriesHeader({
           {t("selected", { num: selectedMemoryIds.length })}{" "}
           <Button
             style="red"
-            onClick={() => {
-              deleteMemories(selectedMemoryIds);
-              setSelectedMemories({});
-            }}
+            onClick={() =>
+              setModal(
+                <ConfirmModal
+                  message={t("confirmDelete", {
+                    num: selectedMemoryIds.length,
+                  })}
+                  onConfirm={() => {
+                    deleteMemories(selectedMemoryIds);
+                    setSelectedMemories({});
+                  }}
+                />
+              )
+            }
             disabled={!selectedMemoryIds.length}
           >
             {t("delete")}

--- a/gakumas-tools/messages/en.json
+++ b/gakumas-tools/messages/en.json
@@ -338,6 +338,7 @@
     "import": "Import memories from screenshots"
   },
   "MemoriesHeader": {
+    "confirmDelete": "Delete {num, plural, one {# memory} other {# memories}}?",
     "selected": "{num} memories selected",
     "delete": "Delete"
   },

--- a/gakumas-tools/messages/ja.json
+++ b/gakumas-tools/messages/ja.json
@@ -346,6 +346,7 @@
     "signInToSave": "Discordでログインして保存"
   },
   "MemoriesHeader": {
+    "confirmDelete": "{num}個のメモリーを削除しますか？",
     "selected": "{num}個のメモリーを選択",
     "delete": "削除する"
   },

--- a/gakumas-tools/messages/ko.json
+++ b/gakumas-tools/messages/ko.json
@@ -338,6 +338,7 @@
     "signInToSave": "Discord로 로그인하여 저장"
   },
   "MemoriesHeader": {
+    "confirmDelete": "메모리 {num}개를 삭제하시겠습니까?",
     "selected": "{num}개의 메모리 선택됨",
     "delete": "삭제하기"
   },

--- a/gakumas-tools/messages/zh-Hans.json
+++ b/gakumas-tools/messages/zh-Hans.json
@@ -338,6 +338,7 @@
     "import": "从截图导入回忆卡"
   },
   "MemoriesHeader": {
+    "confirmDelete": "删除 {num} 个回忆卡？",
     "selected": "{num} 个回忆卡被选中",
     "delete": "删除"
   },


### PR DESCRIPTION
## Problem
In the memories header, entering delete mode, ticking memories and pressing the red **Delete** button removes them immediately. Every other destructive action in the app (clear loadout, clear tier list, remove tier, delete compare run, clear memory calculator) goes through `ConfirmModal`; this one didn't, and deleted memories cannot be recovered.

## Fix
Wrap the delete in `ConfirmModal` with a count-aware message (`MemoriesHeader.confirmDelete`, added to all four locales; the English string uses ICU plural).

Verified with a production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn