### PR TITLE
Load the wasm-only onnxruntime-web bundle

### DIFF
--- a/gakumas-tools/utils/imageProcessing/memory.js
+++ b/gakumas-tools/utils/imageProcessing/memory.js
@@ -1,5 +1,5 @@
 import { PItems, SkillCards } from "gakumas-data";
-import * as ort from "onnxruntime-web";
+import * as ort from "onnxruntime-web/wasm";
 import {
   DEBUG,
   getBlackCanvas,

--- a/gakumas-tools/utils/imageProcessing/models.js
+++ b/gakumas-tools/utils/imageProcessing/models.js
@@ -1,4 +1,4 @@
-import * as ort from "onnxruntime-web";
+import * as ort from "onnxruntime-web/wasm";
 
 function loadModel(modelPath, classesPath) {
   let promise;


### PR DESCRIPTION
## Problem
`import * as ort from "onnxruntime-web"` resolves to the WebGPU/JSEP build (`ort.bundle.min.mjs`). Webpack emits its `ort-wasm-simd-threaded.jsep.wasm` as a static asset, so the first screenshot import (memories or draft pick) downloads:

| | before | after |
|---|---|---|
| wasm | 25.9 MB (`…jsep.wasm`) | 12.8 MB (`ort-wasm-simd-threaded.wasm`) |
| runtime JS chunk | ~394 KB | 70 KB |

Nothing in the app sets `executionProviders` or `ort.env.webgpu`, so inference has always run on the WASM CPU backend; the WebGPU half of the bundle was never used.

## Fix
Import `onnxruntime-web/wasm` in `utils/imageProcessing/models.js` and `memory.js`. Same `InferenceSession` / `Tensor` API and same default backend.

## Verification
- Production build emits `ort-wasm-simd-threaded.<hash>.wasm` (12,810,620 bytes) instead of the JSEP file.
- Loaded both `public/*.onnx` models through `ort.wasm.bundle.min.mjs` in Node and confirmed `InferenceSession.create` succeeds with the expected `input` → `classifier` signature.
- Worth a quick manual smoke test of the memory importer after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn