### PR TITLE
Stop remounting memory rows on every list update

### DIFF
--- a/gakumas-tools/components/Memories/MemoriesList.js
+++ b/gakumas-tools/components/Memories/MemoriesList.js
@@ -5,6 +5,48 @@ import MemorySummary from "@/components/MemorySummary";
 import MemoriesNudge from "./MemoriesNudge";
 import styles from "./Memories.module.scss";
 
+// Defined at module scope so react-window sees one stable component type.
+// When this lived inside MemoriesList's render, every state change (ticking
+// a checkbox, changing the search) handed the list a new component, which
+// unmounted and remounted every visible row, images and drag handlers
+// included.
+const Row = memo(function Row({
+  index,
+  style,
+  ariaAttributes,
+  memories,
+  deleting,
+  picking,
+  selectedMemories,
+  setSelectedMemories,
+  onPick,
+}) {
+  const memory = memories[index];
+  return (
+    <div className={styles.memoryTile} style={style} {...ariaAttributes}>
+      {deleting && (
+        <div className={styles.check}>
+          <input
+            type="checkbox"
+            checked={!!selectedMemories[memory._id]}
+            onChange={(e) =>
+              setSelectedMemories((prev) => ({
+                ...prev,
+                [memory._id]: e.target.checked,
+              }))
+            }
+          />
+        </div>
+      )}
+      <MemorySummary
+        memory={memory}
+        picking={picking}
+        onClick={() => onPick(memory)}
+      />
+    </div>
+  );
+});
+
 function MemoriesList({
   memories,
   deleting,
@@ -13,41 +55,21 @@ function MemoriesList({
   setSelectedMemories,
   onPick,
 }) {
-  const Row = ({ memories, index, style }) => {
-    const memory = memories[index];
-    return (
-      <div className={styles.memoryTile} style={style}>
-        {deleting && (
-          <div className={styles.check}>
-            <input
-              type="checkbox"
-              checked={selectedMemories[memory._id]}
-              onChange={(e) =>
-                setSelectedMemories((prev) => ({
-                  ...prev,
-                  [memory._id]: e.target.checked,
-                }))
-              }
-            />
-          </div>
-        )}
-        <MemorySummary
-          memory={memory}
-          picking={picking}
-          onClick={() => onPick(memory)}
-        />
-      </div>
-    );
-  };
-
   return (
     <div className={styles.list}>
       {memories.length ? (
         <List
-          rowComponent={memo(Row)}
+          rowComponent={Row}
           rowCount={memories.length}
           rowHeight={110}
-          rowProps={{ memories }}
+          rowProps={{
+            memories,
+            deleting,
+            picking,
+            selectedMemories,
+            setSelectedMemories,
+            onPick,
+          }}
         />
       ) : (
         <MemoriesNudge />

--- a/gakumas-tools/components/Memories/MemoriesList.js
+++ b/gakumas-tools/components/Memories/MemoriesList.js
@@ -5,11 +5,6 @@ import MemorySummary from "@/components/MemorySummary";
 import MemoriesNudge from "./MemoriesNudge";
 import styles from "./Memories.module.scss";
 
-// Defined at module scope so react-window sees one stable component type.
-// When this lived inside MemoriesList's render, every state change (ticking
-// a checkbox, changing the search) handed the list a new component, which
-// unmounted and remounted every visible row, images and drag handlers
-// included.
 const Row = memo(function Row({
   index,
   style,


### PR DESCRIPTION
## Problem
`MemoriesList` declared its react-window `Row` inside the component body and passed `rowComponent={memo(Row)}`. Both the function and the `memo` wrapper are re-created on every render, so react-window receives a new component type each time and React unmounts and remounts every visible row. Each row is a `PIdol` image, four p-item icons and up to six skill card icons with react-dnd registrations, so ticking a single checkbox in delete mode, typing in the search, or changing the picker filter tore down and rebuilt ~10 rows of images and drag handlers (visible as flicker/reloading icons).

## Fix
Hoist `Row` to module scope, wrap it in `memo` once, and pass `deleting` / `picking` / `selectedMemories` / `setSelectedMemories` / `onPick` through `rowProps` (react-window v2 spreads these onto the row). Rows now re-render instead of remounting. Also forwards react-window's `ariaAttributes` onto the row element and coerces the checkbox `checked` to a boolean so it stays controlled.

Verified with a production build; used by both the memories page and `MemoryPickerModal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn