### PR TITLE
Memoize context values and setters

### DIFF
--- a/gakumas-tools/contexts/LoadoutContext.js
+++ b/gakumas-tools/contexts/LoadoutContext.js
@@ -1,5 +1,12 @@
 "use client";
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { Stages } from "gakumas-data";
 import { usePathname } from "@/i18n/routing";
 import LoadoutUrlContext from "@/contexts/LoadoutUrlContext";
@@ -65,9 +72,12 @@ export function LoadoutContextProvider({ children }) {
     loadoutsFromUrl.length ? loadoutsFromUrl : [loadout]
   );
 
-  const simulatorUrl = getSimulatorUrl(loadout, loadouts);
+  const simulatorUrl = useMemo(
+    () => getSimulatorUrl(loadout, loadouts),
+    [loadout, loadouts]
+  );
 
-  const setLoadout = (loadout) => {
+  const setLoadout = useCallback((loadout) => {
     setStageId(loadout.stageId);
     if (loadout.stageId == "custom") {
       let custom = loadout.customStage;
@@ -93,7 +103,7 @@ export function LoadoutContextProvider({ children }) {
         console.error(e);
       }
     }
-  };
+  }, []);
 
   useEffect(() => {
     if (["sense", "logic", "anomaly"].includes(stage.plan)) {
@@ -140,7 +150,7 @@ export function LoadoutContextProvider({ children }) {
     }
   }, [pItemIds]);
 
-  function clear() {
+  const clear = useCallback(() => {
     setMemoryParams([null, null]);
     setParams([null, null, null, null]);
     setPItemIds([0, 0, 0, 0]);
@@ -152,25 +162,38 @@ export function LoadoutContextProvider({ children }) {
       [{}, {}, {}, {}, {}, {}],
       [{}, {}, {}, {}, {}, {}],
     ]);
-  }
+  }, []);
 
-  function replacePItemId(index, itemId) {
+  const replacePItemId = useCallback((index, itemId) => {
     setPItemIds((cur) => {
       const next = [...cur];
       next[index] = itemId;
       return next;
     });
-  }
+  }, []);
 
-  function swapPItemIds(indexA, indexB) {
+  const swapPItemIds = useCallback((indexA, indexB) => {
     setPItemIds((cur) => {
       const next = [...cur];
       [next[indexA], next[indexB]] = [next[indexB], next[indexA]];
       return next;
     });
-  }
+  }, []);
 
-  function replaceSkillCardId(index, cardId) {
+  const replaceCustomizations = useCallback((index, customizations) => {
+    setCustomizationGroups((cur) => {
+      const curCustomizations = [].concat(...cur);
+      const updatedCustomizations = [...curCustomizations];
+      updatedCustomizations[index] = customizations;
+      let chunks = [];
+      for (let i = 0; i < updatedCustomizations.length; i += 6) {
+        chunks.push(updatedCustomizations.slice(i, i + 6));
+      }
+      return chunks;
+    });
+  }, []);
+
+  const replaceSkillCardId = useCallback((index, cardId) => {
     let changed = false;
     setSkillCardIdGroups((cur) => {
       const skillCardIds = [].concat(...cur);
@@ -188,9 +211,9 @@ export function LoadoutContextProvider({ children }) {
     if (changed) {
       replaceCustomizations(index, []);
     }
-  }
+  }, [replaceCustomizations]);
 
-  function swapSkillCardIds(indexA, indexB) {
+  const swapSkillCardIds = useCallback((indexA, indexB) => {
     setSkillCardIdGroups((cur) => {
       const skillCardIds = [].concat(...cur);
       const temp = skillCardIds[indexA];
@@ -214,22 +237,9 @@ export function LoadoutContextProvider({ children }) {
       }
       return chunks;
     });
-  }
+  }, []);
 
-  function replaceCustomizations(index, customizations) {
-    setCustomizationGroups((cur) => {
-      const curCustomizations = [].concat(...cur);
-      const updatedCustomizations = [...curCustomizations];
-      updatedCustomizations[index] = customizations;
-      let chunks = [];
-      for (let i = 0; i < updatedCustomizations.length; i += 6) {
-        chunks.push(updatedCustomizations.slice(i, i + 6));
-      }
-      return chunks;
-    });
-  }
-
-  const insertSkillCardIdGroup = (groupIndex) => {
+  const insertSkillCardIdGroup = useCallback((groupIndex) => {
     setSkillCardIdGroups((cur) => {
       const updatedSkillCardIds = [...cur];
       updatedSkillCardIds.splice(groupIndex, 0, [0, 0, 0, 0, 0, 0]);
@@ -240,9 +250,9 @@ export function LoadoutContextProvider({ children }) {
       updatedCustomizations.splice(groupIndex, 0, []);
       return updatedCustomizations;
     });
-  };
+  }, []);
 
-  const deleteSkillCardIdGroup = (groupIndex) => {
+  const deleteSkillCardIdGroup = useCallback((groupIndex) => {
     setSkillCardIdGroups((cur) => {
       const updatedSkillCardIds = [...cur];
       updatedSkillCardIds.splice(groupIndex, 1);
@@ -253,9 +263,9 @@ export function LoadoutContextProvider({ children }) {
       updatedCustomizations.splice(groupIndex, 1);
       return updatedCustomizations;
     });
-  };
+  }, []);
 
-  const swapSkillCardIdGroups = (groupIndexA, groupIndexB) => {
+  const swapSkillCardIdGroups = useCallback((groupIndexA, groupIndexB) => {
     setSkillCardIdGroups((cur) => {
       const updatedSkillCardIds = [...cur];
       const temp = updatedSkillCardIds[groupIndexA];
@@ -270,9 +280,9 @@ export function LoadoutContextProvider({ children }) {
       updatedCustomizations[groupIndexB] = temp;
       return updatedCustomizations;
     });
-  };
+  }, []);
 
-  function setMemory(memory, index) {
+  const setMemory = useCallback((memory, index) => {
     const multiplier = stage.type !== "linkContest" && index ? 0.2 : 1;
 
     if (!memoryParams.some((p) => p)) {
@@ -313,35 +323,55 @@ export function LoadoutContextProvider({ children }) {
       next[index] = memory.customizations || [];
       return next;
     });
-  }
+  }, [stage, memoryParams]);
+
+  const value = useMemo(
+    () => ({
+      loadout,
+      setLoadout,
+      setMemory,
+      setStageId,
+      setCustomStage,
+      setSupportBonus,
+      setParams,
+      replacePItemId,
+      swapPItemIds,
+      replaceSkillCardId,
+      swapSkillCardIds,
+      replaceCustomizations,
+      clear,
+      insertSkillCardIdGroup,
+      deleteSkillCardIdGroup,
+      swapSkillCardIdGroups,
+      stage,
+      simulatorUrl,
+      loadouts,
+      setLoadouts,
+      currentLoadoutIndex,
+      setCurrentLoadoutIndex,
+    }),
+    [
+      loadout,
+      setLoadout,
+      setMemory,
+      replacePItemId,
+      swapPItemIds,
+      replaceSkillCardId,
+      swapSkillCardIds,
+      replaceCustomizations,
+      clear,
+      insertSkillCardIdGroup,
+      deleteSkillCardIdGroup,
+      swapSkillCardIdGroups,
+      stage,
+      simulatorUrl,
+      loadouts,
+      currentLoadoutIndex,
+    ]
+  );
 
   return (
-    <LoadoutContext.Provider
-      value={{
-        loadout,
-        setLoadout,
-        setMemory,
-        setStageId,
-        setCustomStage,
-        setSupportBonus,
-        setParams,
-        replacePItemId,
-        swapPItemIds,
-        replaceSkillCardId,
-        swapSkillCardIds,
-        replaceCustomizations,
-        clear,
-        insertSkillCardIdGroup,
-        deleteSkillCardIdGroup,
-        swapSkillCardIdGroups,
-        stage,
-        simulatorUrl,
-        loadouts,
-        setLoadouts,
-        currentLoadoutIndex,
-        setCurrentLoadoutIndex,
-      }}
-    >
+    <LoadoutContext.Provider value={value}>
       {children}
     </LoadoutContext.Provider>
   );

--- a/gakumas-tools/contexts/LoadoutContext.js
+++ b/gakumas-tools/contexts/LoadoutContext.js
@@ -371,9 +371,7 @@ export function LoadoutContextProvider({ children }) {
   );
 
   return (
-    <LoadoutContext.Provider value={value}>
-      {children}
-    </LoadoutContext.Provider>
+    <LoadoutContext.Provider value={value}>{children}</LoadoutContext.Provider>
   );
 }
 

--- a/gakumas-tools/contexts/LoadoutUrlContext.js
+++ b/gakumas-tools/contexts/LoadoutUrlContext.js
@@ -1,5 +1,5 @@
 "use client";
-import { createContext, useMemo } from "react";
+import { createContext, useCallback, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { Stages } from "gakumas-data";
 import {
@@ -22,7 +22,7 @@ export function LoadoutUrlContextProvider({ children }) {
     []
   );
 
-  const updateUrl = (loadout, loadouts) => {
+  const updateUrl = useCallback((loadout, loadouts) => {
     const url = new URL(window.location);
 
     if (loadout.stageId === "custom") {
@@ -39,12 +39,17 @@ export function LoadoutUrlContextProvider({ children }) {
     }
 
     window.history.replaceState(null, "", url);
-  };
+  }, []);
+
+  // replaceState re-renders every useSearchParams consumer, including this
+  // provider; a stable value keeps that from cascading to the loadout tree.
+  const value = useMemo(
+    () => ({ loadoutFromUrl, loadoutsFromUrl, updateUrl }),
+    [loadoutFromUrl, loadoutsFromUrl, updateUrl]
+  );
 
   return (
-    <LoadoutUrlContext.Provider
-      value={{ loadoutFromUrl, loadoutsFromUrl, updateUrl }}
-    >
+    <LoadoutUrlContext.Provider value={value}>
       {children}
     </LoadoutUrlContext.Provider>
   );

--- a/gakumas-tools/contexts/LoadoutUrlContext.js
+++ b/gakumas-tools/contexts/LoadoutUrlContext.js
@@ -41,8 +41,6 @@ export function LoadoutUrlContextProvider({ children }) {
     window.history.replaceState(null, "", url);
   }, []);
 
-  // replaceState re-renders every useSearchParams consumer, including this
-  // provider; a stable value keeps that from cascading to the loadout tree.
   const value = useMemo(
     () => ({ loadoutFromUrl, loadoutsFromUrl, updateUrl }),
     [loadoutFromUrl, loadoutsFromUrl, updateUrl]

--- a/gakumas-tools/contexts/ModalContext.js
+++ b/gakumas-tools/contexts/ModalContext.js
@@ -1,13 +1,18 @@
 "use client";
-import { createContext, useState, useRef } from "react";
+import { createContext, useCallback, useMemo, useRef, useState } from "react";
 
 const ModalContext = createContext();
 
 export function ModalContextProvider({ children }) {
   const [modals, _setModals] = useState([]);
   const originalFocusRef = useRef(null);
+  // Mirrors `modals` so the depth getter can stay referentially stable while
+  // still reading the current stack at call time (Modal calls it from a
+  // keydown handler).
+  const modalsRef = useRef(modals);
+  modalsRef.current = modals;
 
-  function closeModal() {
+  const closeModal = useCallback(() => {
     _setModals((cur) => {
       const newModals = cur.slice(0, cur.length - 1);
       // If closing the last modal, we'll need to restore focus
@@ -22,9 +27,9 @@ export function ModalContextProvider({ children }) {
       }
       return newModals;
     });
-  }
+  }, []);
 
-  function setModal(modal) {
+  const setModal = useCallback((modal) => {
     _setModals((cur) => {
       // Store the original focused element when opening the first modal
       if (cur.length === 0) {
@@ -32,12 +37,17 @@ export function ModalContextProvider({ children }) {
       }
       return cur.concat(modal);
     });
-  }
+  }, []);
 
-  const getModalStackDepth = () => modals.length;
+  const getModalStackDepth = useCallback(() => modalsRef.current.length, []);
+
+  const value = useMemo(
+    () => ({ setModal, closeModal, getModalStackDepth }),
+    [setModal, closeModal, getModalStackDepth]
+  );
 
   return (
-    <ModalContext.Provider value={{ setModal, closeModal, getModalStackDepth }}>
+    <ModalContext.Provider value={value}>
       <>
         {children}
         {!!modals.length && modals[modals.length - 1]}

--- a/gakumas-tools/contexts/ModalContext.js
+++ b/gakumas-tools/contexts/ModalContext.js
@@ -6,9 +6,6 @@ const ModalContext = createContext();
 export function ModalContextProvider({ children }) {
   const [modals, _setModals] = useState([]);
   const originalFocusRef = useRef(null);
-  // Mirrors `modals` so the depth getter can stay referentially stable while
-  // still reading the current stack at call time (Modal calls it from a
-  // keydown handler).
   const modalsRef = useRef(modals);
   modalsRef.current = modals;
 

--- a/gakumas-tools/contexts/SearchContext.js
+++ b/gakumas-tools/contexts/SearchContext.js
@@ -1,5 +1,5 @@
 "use client";
-import { createContext, useState } from "react";
+import { createContext, useCallback, useMemo, useState } from "react";
 
 const SearchContext = createContext();
 
@@ -7,33 +7,29 @@ export function SearchContextProvider({ children }) {
   const [pItemIds, setPItemIds] = useState([0, 0, 0]);
   const [skillCardIds, setSkillCardIds] = useState([0, 0, 0, 0, 0, 0]);
 
-  function replacePItemId(index, itemId) {
+  const replacePItemId = useCallback((index, itemId) => {
     setPItemIds((cur) => {
       const next = [...cur];
       next[index] = itemId;
       return next;
     });
-  }
+  }, []);
 
-  function replaceSkillCardId(index, cardId) {
+  const replaceSkillCardId = useCallback((index, cardId) => {
     setSkillCardIds((cur) => {
       const next = [...cur];
       next[index] = cardId;
       return next;
     });
-  }
+  }, []);
+
+  const value = useMemo(
+    () => ({ pItemIds, skillCardIds, replacePItemId, replaceSkillCardId }),
+    [pItemIds, skillCardIds, replacePItemId, replaceSkillCardId]
+  );
 
   return (
-    <SearchContext.Provider
-      value={{
-        pItemIds,
-        skillCardIds,
-        replacePItemId,
-        replaceSkillCardId,
-      }}
-    >
-      {children}
-    </SearchContext.Provider>
+    <SearchContext.Provider value={value}>{children}</SearchContext.Provider>
   );
 }
 

--- a/gakumas-tools/contexts/WorkspaceContext.js
+++ b/gakumas-tools/contexts/WorkspaceContext.js
@@ -1,5 +1,12 @@
 "use client";
-import { createContext, useCallback, useEffect, useRef, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   DEFAULT_WORKSPACE,
   parseWorkspace,
@@ -48,34 +55,31 @@ export function WorkspaceContextProvider({ initialWorkspace, children }) {
     writeWorkspaceCookie({ filter, plan, idolId, pinnedTools });
   }, [filter, plan, idolId, pinnedTools]);
 
-  const pin = useCallback(
-    (tool) => {
-      setPinnedTools([...pinnedTools, tool]);
-    },
-    [pinnedTools]
-  );
+  const pin = useCallback((tool) => {
+    setPinnedTools((cur) => [...cur, tool]);
+  }, []);
 
-  const unpin = useCallback(
-    (tool) => {
-      setPinnedTools(pinnedTools.filter((t) => t != tool));
-    },
-    [pinnedTools]
+  const unpin = useCallback((tool) => {
+    setPinnedTools((cur) => cur.filter((t) => t != tool));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      filter,
+      setFilter,
+      plan,
+      setPlan,
+      idolId,
+      setIdolId,
+      pinnedTools,
+      pin,
+      unpin,
+    }),
+    [filter, plan, idolId, pinnedTools, pin, unpin]
   );
 
   return (
-    <WorkspaceContext.Provider
-      value={{
-        filter,
-        setFilter,
-        plan,
-        setPlan,
-        idolId,
-        setIdolId,
-        pinnedTools,
-        pin,
-        unpin,
-      }}
-    >
+    <WorkspaceContext.Provider value={value}>
       {children}
     </WorkspaceContext.Provider>
   );


### PR DESCRIPTION
## Problem
`ModalContext`, `LoadoutUrlContext`, `LoadoutContext`, `WorkspaceContext` and `SearchContext` pass a fresh `value={{ ... }}` object on every render, so every consumer re-renders whenever the provider does, even when nothing it reads changed. (`SimulationRunsContext` and `NavigationGuardContext` already memoize.)

Two concrete hot paths:

- **Typing in the simulator.** `LoadoutContext` calls `history.replaceState` on each loadout change. Next 16 patches `replaceState` to dispatch a router action, which re-renders every `useSearchParams` / `usePathname` consumer. `LoadoutUrlContextProvider` uses `useSearchParams`, so it re-rendered with a new value → `LoadoutContextProvider` re-rendered with a new value → all nine `LoadoutContext` consumers (editor, card groups, 16–22 entity icons, buttons, stage select, results) rendered a second time per keystroke.
- **Opening or closing any modal** re-rendered all 21 `ModalContext` consumers, and `Modal` re-subscribed its keydown listener because `getModalStackDepth` was a new function each time.

## Fix
- Setters wrapped in `useCallback`; `pin`/`unpin` and the loadout mutators use functional updates so they need no state deps. `setMemory` keeps `[stage, memoryParams]` since it reads both.
- `getModalStackDepth` reads the stack through a ref, so it stays stable while still returning the live depth when `Modal` calls it from the keydown handler.
- `replaceCustomizations` moved above `replaceSkillCardId`, which depends on it (a `const` can't be referenced in a deps array before its declaration).
- Each provider's `value` is `useMemo`'d.

No behaviour changes intended. Verified with a production build. Worth a quick manual pass over the simulator (swap/remove cards, add/remove card groups, link contest stages, set memory) and modal stacking (Escape with a picker open inside the stamina calculator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn