### PR TITLE
Share simulator workers and recover from failed runs

### DIFF
--- a/gakumas-tools/components/Simulator/Simulator.js
+++ b/gakumas-tools/components/Simulator/Simulator.js
@@ -34,12 +34,12 @@ import LoadoutContext from "@/contexts/LoadoutContext";
 import SimulationRunsContext from "@/contexts/SimulationRunsContext";
 import WorkspaceContext from "@/contexts/WorkspaceContext";
 import { simulate } from "@/simulator";
+import { DEFAULT_NUM_RUNS, SYNC } from "@/simulator/constants";
 import {
-  MAX_WORKERS,
-  DEFAULT_NUM_RUNS,
-  SYNC,
-  WORKER_MESSAGE,
-} from "@/simulator/constants";
+  retainWorkerPool,
+  runOnWorkers,
+  workerCount,
+} from "@/simulator/workerPool";
 import { bucketScores, getMedianScore, mergeResults } from "@/utils/simulator";
 import usePersistedState from "@/utils/usePersistedState";
 import ManualPlay from "./ManualPlay";
@@ -68,12 +68,12 @@ export default function Simulator() {
   const [strategy, setStrategy] = useState("HeuristicStrategy");
   const [simulatorData, setSimulatorData] = useState(null);
   const [running, setRunning] = useState(false);
+  const [failed, setFailed] = useState(false);
   const [numRuns, setNumRuns] = usePersistedState(
     NUM_RUNS_KEY,
     DEFAULT_NUM_RUNS,
   );
   const [enterPercents, setEnterPercents] = useState(false);
-  const workersRef = useRef();
 
   const [pendingDecision, setPendingDecision] = useState(null);
   const resolveDecisionRef = useRef(null);
@@ -109,25 +109,14 @@ export default function Simulator() {
     });
   }, [loadouts, stage, enterPercents]);
 
-  // Set up web workers on mount
   useEffect(() => {
-    let numWorkers = 1;
-    if (navigator.hardwareConcurrency) {
-      numWorkers = Math.min(navigator.hardwareConcurrency, MAX_WORKERS);
-    }
     // Seed a hardware-scaled default only when the user has no saved value.
     if (localStorage.getItem(NUM_RUNS_KEY) == null) {
-      setNumRuns(Math.round(Math.min(numWorkers, MAX_WORKERS) / 2) * 1000);
+      setNumRuns(Math.round(workerCount() / 2) * 1000);
     }
-
-    workersRef.current = [];
-    for (let i = 0; i < numWorkers; i++) {
-      workersRef.current.push(
-        new Worker(new URL("../../simulator/worker.js", import.meta.url)),
-      );
-    }
-
-    return () => workersRef.current?.forEach((worker) => worker.terminate());
+    // Workers are shared with any other mounted Simulator (e.g. a pinned
+    // copy) and spawned on the first run.
+    return retainWorkerPool();
   }, []);
 
   const setResult = useCallback(
@@ -186,48 +175,39 @@ export default function Simulator() {
 
   async function runSimulation() {
     setRunning(true);
+    setFailed(false);
     setProgress(0);
 
     console.time("simulation");
 
-    if (SYNC || !workersRef.current) {
-      const result = await simulate(
-        config,
-        linkConfigs,
-        strategy,
-        numRuns,
-        (completed) => setProgress(completed),
-      );
-      setResult(result);
-    } else {
-      const numWorkers = workersRef.current.length;
-      const runsPerWorker = Math.round(numRuns / numWorkers);
-
-      let promises = [];
-      for (let i = 0; i < numWorkers; i++) {
-        promises.push(
-          new Promise((resolve) => {
-            workersRef.current[i].onmessage = (e) => {
-              if (e.data.type === WORKER_MESSAGE.PROGRESS) {
-                setProgress((p) => p + e.data.delta);
-              } else if (e.data.type === WORKER_MESSAGE.RESULT) {
-                resolve(e.data.result);
-              }
-            };
-            workersRef.current[i].postMessage({
-              idolStageConfig: config,
-              linkConfigs: linkConfigs,
-              strategyName: strategy,
-              numRuns: runsPerWorker,
-            });
-          }),
+    try {
+      let result;
+      if (SYNC) {
+        result = await simulate(
+          config,
+          linkConfigs,
+          strategy,
+          numRuns,
+          (completed) => setProgress(completed),
         );
+      } else {
+        const results = await runOnWorkers(
+          {
+            idolStageConfig: config,
+            linkConfigs,
+            strategyName: strategy,
+            numRuns,
+          },
+          (delta) => setProgress((p) => p + delta),
+        );
+        result = mergeResults(results);
       }
-
-      Promise.all(promises).then((results) => {
-        const mergedResults = mergeResults(results);
-        setResult(mergedResults);
-      });
+      setResult(result);
+    } catch (err) {
+      console.error(err);
+      console.timeEnd("simulation");
+      setFailed(true);
+      setRunning(false);
     }
   }
 
@@ -395,6 +375,7 @@ export default function Simulator() {
         />
       )}
 
+      {failed && <Alert variant="danger">{t("simulationFailed")}</Alert>}
       {!simulatorData && <div className={styles.resultPlaceholder} />}
     </div>
   );

--- a/gakumas-tools/components/Simulator/Simulator.js
+++ b/gakumas-tools/components/Simulator/Simulator.js
@@ -114,8 +114,6 @@ export default function Simulator() {
     if (localStorage.getItem(NUM_RUNS_KEY) == null) {
       setNumRuns(Math.round(workerCount() / 2) * 1000);
     }
-    // Workers are shared with any other mounted Simulator (e.g. a pinned
-    // copy) and spawned on the first run.
     return retainWorkerPool();
   }, []);
 

--- a/gakumas-tools/messages/en.json
+++ b/gakumas-tools/messages/en.json
@@ -358,7 +358,8 @@
     "provideData": "Provide data",
     "lastUpdated": "Last updated",
     "start": "Start",
-    "restart": "Restart"
+    "restart": "Restart",
+    "simulationFailed": "Simulation failed. Please try again."
   },
   "StrategyPicker": {
     "auto": "Auto",

--- a/gakumas-tools/messages/ja.json
+++ b/gakumas-tools/messages/ja.json
@@ -366,7 +366,8 @@
     "provideData": "データを提供する",
     "lastUpdated": "最終更新",
     "start": "開始",
-    "restart": "再開"
+    "restart": "再開",
+    "simulationFailed": "シミュレーションに失敗しました。もう一度お試しください。"
   },
   "StrategyPicker": {
     "auto": "自動",

--- a/gakumas-tools/messages/ko.json
+++ b/gakumas-tools/messages/ko.json
@@ -358,7 +358,8 @@
     "provideData": "데이터 제공하기",
     "lastUpdated": "최종 업데이트",
     "start": "시작",
-    "restart": "재시작"
+    "restart": "재시작",
+    "simulationFailed": "시뮬레이션에 실패했습니다. 다시 시도해 주세요."
   },
   "StrategyPicker": {
     "auto": "자동",

--- a/gakumas-tools/messages/zh-Hans.json
+++ b/gakumas-tools/messages/zh-Hans.json
@@ -358,7 +358,8 @@
     "provideData": "提供数据",
     "lastUpdated": "最后更新于",
     "start": "开始",
-    "restart": "重新开始"
+    "restart": "重新开始",
+    "simulationFailed": "模拟失败，请重试。"
   },
   "StrategyPicker": {
     "auto": "自动",

--- a/gakumas-tools/simulator/constants.js
+++ b/gakumas-tools/simulator/constants.js
@@ -6,6 +6,7 @@ export const MAX_WORKERS = 8;
 export const WORKER_MESSAGE = {
   PROGRESS: "progress",
   RESULT: "result",
+  ERROR: "error",
 };
 
 export const FALLBACK_STAGE = {

--- a/gakumas-tools/simulator/worker.js
+++ b/gakumas-tools/simulator/worker.js
@@ -2,18 +2,28 @@ import { simulate } from ".";
 import { WORKER_MESSAGE } from "./constants";
 
 addEventListener("message", async (e) => {
-  const { idolStageConfig, linkConfigs, strategyName, numRuns } = e.data;
+  const { runId, idolStageConfig, linkConfigs, strategyName, numRuns } =
+    e.data;
   let lastReported = 0;
-  const result = await simulate(
-    idolStageConfig,
-    linkConfigs,
-    strategyName,
-    numRuns,
-    (completed) => {
-      const delta = completed - lastReported;
-      lastReported = completed;
-      postMessage({ type: WORKER_MESSAGE.PROGRESS, delta });
-    }
-  );
-  postMessage({ type: WORKER_MESSAGE.RESULT, result });
+  try {
+    const result = await simulate(
+      idolStageConfig,
+      linkConfigs,
+      strategyName,
+      numRuns,
+      (completed) => {
+        const delta = completed - lastReported;
+        lastReported = completed;
+        postMessage({ type: WORKER_MESSAGE.PROGRESS, runId, delta });
+      }
+    );
+    postMessage({ type: WORKER_MESSAGE.RESULT, runId, result });
+  } catch (err) {
+    console.error(err);
+    postMessage({
+      type: WORKER_MESSAGE.ERROR,
+      runId,
+      message: err?.message || String(err),
+    });
+  }
 });

--- a/gakumas-tools/simulator/worker.js
+++ b/gakumas-tools/simulator/worker.js
@@ -2,8 +2,7 @@ import { simulate } from ".";
 import { WORKER_MESSAGE } from "./constants";
 
 addEventListener("message", async (e) => {
-  const { runId, idolStageConfig, linkConfigs, strategyName, numRuns } =
-    e.data;
+  const { runId, idolStageConfig, linkConfigs, strategyName, numRuns } = e.data;
   let lastReported = 0;
   try {
     const result = await simulate(

--- a/gakumas-tools/simulator/workerPool.js
+++ b/gakumas-tools/simulator/workerPool.js
@@ -1,0 +1,82 @@
+import { MAX_WORKERS, WORKER_MESSAGE } from "./constants";
+
+let workers = null;
+let holders = 0;
+let nextRunId = 0;
+
+export function workerCount() {
+  return Math.min(navigator.hardwareConcurrency || 1, MAX_WORKERS);
+}
+
+// Call from a mount effect and run the returned release on unmount. The pool
+// is shared by every mounted Simulator (the page and a pinned copy), spawned
+// on first use, and terminated once the last holder unmounts.
+export function retainWorkerPool() {
+  holders++;
+  return () => {
+    holders--;
+    if (holders > 0) return;
+    holders = 0;
+    workers?.forEach((worker) => worker.terminate());
+    workers = null;
+  };
+}
+
+function getWorkerPool() {
+  if (!workers) {
+    workers = Array.from(
+      { length: workerCount() },
+      () => new Worker(new URL("./worker.js", import.meta.url))
+    );
+  }
+  return workers;
+}
+
+// Splits `numRuns` across the pool and resolves with one result per worker.
+// Messages carry a run id so concurrent runs from two Simulator instances
+// sharing the pool don't read each other's progress or results.
+export function runOnWorkers(
+  { idolStageConfig, linkConfigs, strategyName, numRuns },
+  onProgress
+) {
+  const pool = getWorkerPool();
+  const runId = nextRunId++;
+  const runsPerWorker = Math.round(numRuns / pool.length);
+
+  return Promise.all(
+    pool.map(
+      (worker) =>
+        new Promise((resolve, reject) => {
+          const cleanup = () => {
+            worker.removeEventListener("message", onMessage);
+            worker.removeEventListener("error", onError);
+          };
+          const onMessage = (e) => {
+            if (e.data.runId !== runId) return;
+            if (e.data.type === WORKER_MESSAGE.PROGRESS) {
+              onProgress(e.data.delta);
+            } else if (e.data.type === WORKER_MESSAGE.RESULT) {
+              cleanup();
+              resolve(e.data.result);
+            } else if (e.data.type === WORKER_MESSAGE.ERROR) {
+              cleanup();
+              reject(new Error(e.data.message));
+            }
+          };
+          const onError = (e) => {
+            cleanup();
+            reject(e.error || new Error(e.message || "Worker failed"));
+          };
+          worker.addEventListener("message", onMessage);
+          worker.addEventListener("error", onError);
+          worker.postMessage({
+            runId,
+            idolStageConfig,
+            linkConfigs,
+            strategyName,
+            numRuns: runsPerWorker,
+          });
+        })
+    )
+  );
+}

--- a/gakumas-tools/simulator/workerPool.js
+++ b/gakumas-tools/simulator/workerPool.js
@@ -8,15 +8,12 @@ export function workerCount() {
   return Math.min(navigator.hardwareConcurrency || 1, MAX_WORKERS);
 }
 
-// Call from a mount effect and run the returned release on unmount. The pool
-// is shared by every mounted Simulator (the page and a pinned copy), spawned
-// on first use, and terminated once the last holder unmounts.
+// Call from a mount effect and run the returned release on unmount.
 export function retainWorkerPool() {
   holders++;
   return () => {
     holders--;
     if (holders > 0) return;
-    holders = 0;
     workers?.forEach((worker) => worker.terminate());
     workers = null;
   };
@@ -32,14 +29,12 @@ function getWorkerPool() {
   return workers;
 }
 
-// Splits `numRuns` across the pool and resolves with one result per worker.
-// Messages carry a run id so concurrent runs from two Simulator instances
-// sharing the pool don't read each other's progress or results.
 export function runOnWorkers(
   { idolStageConfig, linkConfigs, strategyName, numRuns },
   onProgress
 ) {
   const pool = getWorkerPool();
+  // Two Simulators can share the pool, so each run tags its own messages.
   const runId = nextRunId++;
   const runsPerWorker = Math.round(numRuns / pool.length);
 
@@ -47,28 +42,31 @@ export function runOnWorkers(
     pool.map(
       (worker) =>
         new Promise((resolve, reject) => {
-          const cleanup = () => {
-            worker.removeEventListener("message", onMessage);
-            worker.removeEventListener("error", onError);
-          };
-          const onMessage = (e) => {
-            if (e.data.runId !== runId) return;
-            if (e.data.type === WORKER_MESSAGE.PROGRESS) {
-              onProgress(e.data.delta);
-            } else if (e.data.type === WORKER_MESSAGE.RESULT) {
-              cleanup();
-              resolve(e.data.result);
-            } else if (e.data.type === WORKER_MESSAGE.ERROR) {
-              cleanup();
-              reject(new Error(e.data.message));
-            }
-          };
-          const onError = (e) => {
-            cleanup();
-            reject(e.error || new Error(e.message || "Worker failed"));
-          };
-          worker.addEventListener("message", onMessage);
-          worker.addEventListener("error", onError);
+          const listeners = new AbortController();
+          worker.addEventListener(
+            "message",
+            ({ data }) => {
+              if (data.runId !== runId) return;
+              if (data.type === WORKER_MESSAGE.PROGRESS) {
+                onProgress(data.delta);
+              } else if (data.type === WORKER_MESSAGE.RESULT) {
+                listeners.abort();
+                resolve(data.result);
+              } else if (data.type === WORKER_MESSAGE.ERROR) {
+                listeners.abort();
+                reject(new Error(data.message));
+              }
+            },
+            { signal: listeners.signal }
+          );
+          worker.addEventListener(
+            "error",
+            (e) => {
+              listeners.abort();
+              reject(e.error || new Error(e.message || "Worker failed"));
+            },
+            { signal: listeners.signal }
+          );
           worker.postMessage({
             runId,
             idolStageConfig,


### PR DESCRIPTION
## Problem
- `Simulator` spawned `min(hardwareConcurrency, 8)` Web Workers in a mount effect, each booting the engine and dataset, even if the user never pressed Simulate. When the simulator is pinned while on `/simulator`, two instances mount and that doubles to up to 16 workers.
- A run had no failure path. `Promise.all(promises).then(...)` had no `.catch`, and workers had no `error` handler, so any exception during a run left `running` at `true` with the Simulate button disabled until a reload.

## Fix
- New `simulator/workerPool.js`: one module-level pool, spawned lazily on the first run, ref-counted by mounted `Simulator` instances (`retainWorkerPool()` in the mount effect, release on unmount) and terminated when the last instance goes away.
- `runOnWorkers()` splits runs across the pool with `addEventListener` per run and a `runId` on every message, so two instances simulating at the same time don't consume each other's progress or results (previously each instance had its own workers; a shared pool needs this).
- The worker wraps `simulate` in try/catch and posts an `ERROR` message; `runOnWorkers` rejects on that or on the worker's `error` event. `runSimulation` catches, resets `running`, and shows an alert (`Simulator.simulationFailed`, added to all four locales).
- The `SYNC` debug path is preserved.

Verified with a production build (worker chunk emitted with run-id tagging). Worth a manual run of a normal contest, a link contest, and the simulator with a pinned copy open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn