### PR TITLE
Index per-user collections and harden the Mongo connection

### DIFF
--- a/gakumas-tools/utils/mongodb.js
+++ b/gakumas-tools/utils/mongodb.js
@@ -14,6 +14,14 @@ if (!MONGODB_DB) {
   );
 }
 
+// Every API query is scoped by userId (and loadouts are sorted by createdAt),
+// so without these the driver scans the whole collection per request.
+// createIndex is idempotent; it runs once per process after connecting.
+const INDEXES = [
+  ["memories", { userId: 1 }],
+  ["loadouts", { userId: 1, createdAt: -1 }],
+];
+
 /**
  * Global is used here to maintain a cached connection across hot reloads
  * in development. This prevents connections growing exponentially
@@ -25,16 +33,41 @@ if (!cached) {
   cached = global.mongo = { conn: null, promise: null };
 }
 
+async function ensureIndexes(db) {
+  try {
+    await Promise.all(
+      INDEXES.map(([name, keys]) => db.collection(name).createIndex(keys))
+    );
+  } catch (err) {
+    // Index creation needs privileges the API user may not have; queries
+    // still work without them, so don't fail the connection.
+    console.warn("mongodb: could not ensure indexes:", err?.message || err);
+  }
+}
+
+async function createConnection() {
+  const client = await MongoClient.connect(MONGODB_URI, {
+    // Fail API calls quickly when the cluster is unreachable instead of
+    // hanging for the driver's 30s default.
+    serverSelectionTimeoutMS: 5000,
+  });
+  const db = client.db(MONGODB_DB);
+  await ensureIndexes(db);
+  return { client, db };
+}
+
 export async function connect() {
   if (cached.conn) {
     return cached.conn;
   }
 
   if (!cached.promise) {
-    cached.promise = MongoClient.connect(MONGODB_URI).then((client) => ({
-      client,
-      db: client.db(MONGODB_DB),
-    }));
+    cached.promise = createConnection().catch((err) => {
+      // Drop the rejected promise so the next request retries rather than
+      // every request failing until the process restarts.
+      cached.promise = null;
+      throw err;
+    });
   }
 
   cached.conn = await cached.promise;

--- a/gakumas-tools/utils/mongodb.js
+++ b/gakumas-tools/utils/mongodb.js
@@ -14,13 +14,10 @@ if (!MONGODB_DB) {
   );
 }
 
-// Every API query is scoped by userId (and loadouts are sorted by createdAt),
-// so without these the driver scans the whole collection per request.
-// createIndex is idempotent; it runs once per process after connecting.
-const INDEXES = [
-  ["memories", { userId: 1 }],
-  ["loadouts", { userId: 1, createdAt: -1 }],
-];
+const INDEXES = {
+  memories: { userId: 1 },
+  loadouts: { userId: 1, createdAt: -1 },
+};
 
 /**
  * Global is used here to maintain a cached connection across hot reloads
@@ -36,19 +33,17 @@ if (!cached) {
 async function ensureIndexes(db) {
   try {
     await Promise.all(
-      INDEXES.map(([name, keys]) => db.collection(name).createIndex(keys))
+      Object.entries(INDEXES).map(([name, keys]) =>
+        db.collection(name).createIndex(keys)
+      )
     );
   } catch (err) {
-    // Index creation needs privileges the API user may not have; queries
-    // still work without them, so don't fail the connection.
     console.warn("mongodb: could not ensure indexes:", err?.message || err);
   }
 }
 
 async function createConnection() {
   const client = await MongoClient.connect(MONGODB_URI, {
-    // Fail API calls quickly when the cluster is unreachable instead of
-    // hanging for the driver's 30s default.
     serverSelectionTimeoutMS: 5000,
   });
   const db = client.db(MONGODB_DB);
@@ -63,8 +58,7 @@ export async function connect() {
 
   if (!cached.promise) {
     cached.promise = createConnection().catch((err) => {
-      // Drop the rejected promise so the next request retries rather than
-      // every request failing until the process restarts.
+      // Let the next request retry instead of awaiting this rejection.
       cached.promise = null;
       throw err;
     });


### PR DESCRIPTION
## Problem
- `GET /api/memory` runs `find({ userId })` and `GET /api/loadout` runs `find({ userId }).sort({ createdAt: -1 })`, but nothing in the repo creates an index on either collection. Each request is a full collection scan across every user's documents, plus an in-memory sort for loadouts. Memories are bulk-imported via OCR, so the collection grows quickly.
- `utils/mongodb.js` caches `MongoClient.connect(...)` without a `.catch`. If the first connection attempt rejects (DNS/Atlas hiccup at boot), every later request awaits the same rejected promise until the container restarts.
- No `serverSelectionTimeoutMS`, so API calls hang for the driver's 30 s default when the cluster is unreachable.

## Fix
- After connecting, `createIndex` on `memories { userId: 1 }` and `loadouts { userId: 1, createdAt: -1 }`. `createIndex` is idempotent and runs once per process; if the API user lacks index privileges it logs a warning and continues.
- `serverSelectionTimeoutMS: 5000`.
- The cached promise is cleared on rejection so the next request retries.

Verified with a production build. The first request after deploy will build the indexes (fast on collections of this size).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn