### PR TITLE
Load the Oshi banner only when configured

### DIFF
--- a/gakumas-tools/components/Navbar/Navbar.js
+++ b/gakumas-tools/components/Navbar/Navbar.js
@@ -1,8 +1,9 @@
 "use client";
 import { memo, useEffect, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import { Link, usePathname } from "@/i18n/routing";
-import Oshi, { OSHI_PROPS } from "@/components/Oshi";
+import { OSHI_PROPS } from "@/components/Oshi/config";
 import ToolHeader from "@/components/ToolHeader";
 import c from "@/utils/classNames";
 import { TOOLS } from "@/utils/tools";
@@ -13,6 +14,9 @@ import styles from "./Navbar.module.scss";
 // Width of the underline relative to the link itself (60% = matches the old
 // `left: 20%; right: 20%` styling).
 const INDICATOR_FRACTION = 0.6;
+
+// Only loaded when a banner is configured.
+const Oshi = dynamic(() => import("@/components/Oshi"));
 
 function Navbar() {
   const t = useTranslations("tools");

--- a/gakumas-tools/components/Oshi/Oshi.js
+++ b/gakumas-tools/components/Oshi/Oshi.js
@@ -5,8 +5,6 @@ import IdolIcon from "@/components/IdolIcon";
 import YouTubeVideo from "@/components/YouTubeVideo";
 import styles from "./Oshi.module.scss";
 
-export const OSHI_PROPS = null;
-
 export default function Oshi({
   text,
   initiallyExpanded,

--- a/gakumas-tools/components/Oshi/config.js
+++ b/gakumas-tools/components/Oshi/config.js
@@ -1,0 +1,4 @@
+// Props for the promotional banner under the navbar, or null to hide it.
+// Kept apart from the component so the navbar can check this without
+// bundling the banner (and re-resizable) on every page.
+export const OSHI_PROPS = null;

--- a/gakumas-tools/components/Oshi/index.js
+++ b/gakumas-tools/components/Oshi/index.js
@@ -1,1 +1,2 @@
-export { default, OSHI_PROPS } from "./Oshi";
+export { default } from "./Oshi";
+export { OSHI_PROPS } from "./config";


### PR DESCRIPTION
## Problem
`Navbar` imports `Oshi` (and `OSHI_PROPS`) from `components/Oshi`, so `re-resizable` and the banner component are part of the shared chunk on every page, even though `OSHI_PROPS` is `null` and nothing renders.

## Fix
- `OSHI_PROPS` moves to `components/Oshi/config.js` (no heavy imports); `components/Oshi/index.js` re-exports it so existing import paths keep working.
- `Navbar` reads the flag from the config module and loads the component via `next/dynamic`, so the banner chunk is only fetched when a banner is configured.

## Measured (first-load JS of served HTML)

| route | before | after |
|---|---|---|
| `/` | 1347.8 KB raw / 307.8 KB gz | 1332.0 KB / 303.5 KB gz |
| `/simulator` | 1739.2 KB / 431.5 KB gz | 1723.3 KB / 427.2 KB gz |

Small, but it applies to every page. Verified with a production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn