### PR TITLE
Cache preview images and prerender OG images

### DIFF
--- a/gakumas-tools/app/[locale]/calculator/hajime/produce-rank/opengraph-image.js
+++ b/gakumas-tools/app/[locale]/calculator/hajime/produce-rank/opengraph-image.js
@@ -1,5 +1,8 @@
 import { ogImageRoute, OG_SIZE, OG_CONTENT_TYPE } from "@/utils/og";
 
+// Depends only on the locale, so prerender it at build time.
+export const dynamic = "force-static";
+
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 export const alt = "Gakumas Tools";

--- a/gakumas-tools/app/[locale]/calculator/hajime/produce-rank/opengraph-image.js
+++ b/gakumas-tools/app/[locale]/calculator/hajime/produce-rank/opengraph-image.js
@@ -1,6 +1,5 @@
 import { ogImageRoute, OG_SIZE, OG_CONTENT_TYPE } from "@/utils/og";
 
-// Depends only on the locale, so prerender it at build time.
 export const dynamic = "force-static";
 
 export const size = OG_SIZE;

--- a/gakumas-tools/app/[locale]/calculator/hif/opengraph-image.js
+++ b/gakumas-tools/app/[locale]/calculator/hif/opengraph-image.js
@@ -1,5 +1,8 @@
 import { ogImageRoute, OG_SIZE, OG_CONTENT_TYPE } from "@/utils/og";
 
+// Depends only on the locale, so prerender it at build time.
+export const dynamic = "force-static";
+
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 export const alt = "Gakumas Tools";

--- a/gakumas-tools/app/[locale]/calculator/hif/opengraph-image.js
+++ b/gakumas-tools/app/[locale]/calculator/hif/opengraph-image.js
@@ -1,6 +1,5 @@
 import { ogImageRoute, OG_SIZE, OG_CONTENT_TYPE } from "@/utils/og";
 
-// Depends only on the locale, so prerender it at build time.
 export const dynamic = "force-static";
 
 export const size = OG_SIZE;

--- a/gakumas-tools/app/[locale]/calculator/nia/opengraph-image.js
+++ b/gakumas-tools/app/[locale]/calculator/nia/opengraph-image.js
@@ -1,5 +1,8 @@
 import { ogImageRoute, OG_SIZE, OG_CONTENT_TYPE } from "@/utils/og";
 
+// Depends only on the locale, so prerender it at build time.
+export const dynamic = "force-static";
+
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 export const alt = "Gakumas Tools";

--- a/gakumas-tools/app/[locale]/calculator/nia/opengraph-image.js
+++ b/gakumas-tools/app/[locale]/calculator/nia/opengraph-image.js
@@ -1,6 +1,5 @@
 import { ogImageRoute, OG_SIZE, OG_CONTENT_TYPE } from "@/utils/og";
 
-// Depends only on the locale, so prerender it at build time.
 export const dynamic = "force-static";
 
 export const size = OG_SIZE;

--- a/gakumas-tools/app/[locale]/dex/tier-list/[type]/page.js
+++ b/gakumas-tools/app/[locale]/dex/tier-list/[type]/page.js
@@ -31,7 +31,7 @@ export async function generateMetadata({ params, searchParams }) {
   if (entityType) {
     const query = new URLSearchParams(await searchParams);
     query.set("type", entityType);
-    metadata.openGraph.images = [`/api/tier-list-preview/?${query.toString()}`];
+    metadata.openGraph.images = [`/api/tier-list-preview?${query.toString()}`];
   }
 
   return metadata;

--- a/gakumas-tools/app/[locale]/opengraph-image.js
+++ b/gakumas-tools/app/[locale]/opengraph-image.js
@@ -1,5 +1,8 @@
 import { ogImageRoute, OG_SIZE, OG_CONTENT_TYPE } from "@/utils/og";
 
+// Depends only on the locale, so prerender it at build time.
+export const dynamic = "force-static";
+
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 export const alt = "Gakumas Tools";

--- a/gakumas-tools/app/[locale]/opengraph-image.js
+++ b/gakumas-tools/app/[locale]/opengraph-image.js
@@ -1,6 +1,5 @@
 import { ogImageRoute, OG_SIZE, OG_CONTENT_TYPE } from "@/utils/og";
 
-// Depends only on the locale, so prerender it at build time.
 export const dynamic = "force-static";
 
 export const size = OG_SIZE;

--- a/gakumas-tools/app/[locale]/simulator/page.js
+++ b/gakumas-tools/app/[locale]/simulator/page.js
@@ -6,7 +6,7 @@ export async function generateMetadata({ params, searchParams }) {
   const { locale } = await params;
   const metadata = await generateMetadataForTool("simulator", locale, "/simulator");
   const query = new URLSearchParams(await searchParams).toString();
-  metadata.openGraph.images = [`/api/preview/?${query}`];
+  metadata.openGraph.images = [`/api/preview?${query}`];
 
   return metadata;
 }

--- a/gakumas-tools/app/api/preview/route.js
+++ b/gakumas-tools/app/api/preview/route.js
@@ -4,6 +4,7 @@ import { IdolConfig } from "gakumas-engine";
 import gkImg from "gakumas-images";
 import { PItems, SkillCards } from "gakumas-data";
 import Preview from "@/components/Preview";
+import { PREVIEW_CACHE_CONTROL } from "@/utils/og";
 import { loadoutFromSearchParams } from "@/utils/simulator";
 
 const PNG_CACHE_LIMIT = 500;
@@ -92,6 +93,6 @@ export async function GET(request) {
         imageMap={imageMap}
       />
     ),
-    { width: 470, height }
+    { width: 470, height, headers: { "Cache-Control": PREVIEW_CACHE_CONTROL } }
   );
 }

--- a/gakumas-tools/app/api/tier-list-preview/route.js
+++ b/gakumas-tools/app/api/tier-list-preview/route.js
@@ -17,6 +17,7 @@ import {
   EntityTypes,
   resolveEntityIcon,
 } from "@/utils/entities";
+import { PREVIEW_CACHE_CONTROL } from "@/utils/og";
 import { decodeList, EMPTY_LIST } from "@/utils/tierList";
 
 const PNG_CACHE_LIMIT = 500;
@@ -144,6 +145,10 @@ export async function GET(request) {
 
   return new ImageResponse(
     <TierListPreview list={list} rankSrc={rankSrc} itemSrc={itemSrc} />,
-    { width: PREVIEW_WIDTH, height },
+    {
+      width: PREVIEW_WIDTH,
+      height,
+      headers: { "Cache-Control": PREVIEW_CACHE_CONTROL },
+    },
   );
 }

--- a/gakumas-tools/utils/og.js
+++ b/gakumas-tools/utils/og.js
@@ -6,6 +6,13 @@ import { SITE_URL } from "@/utils/localeUrls";
 export const OG_SIZE = { width: 1200, height: 630 };
 export const OG_CONTENT_TYPE = "image/png";
 
+// Query-driven preview images are pure functions of their URL and the
+// bundled data; let browsers and the CDN reuse them instead of re-running
+// satori + resvg for every crawler hit. Data changes ship with a deploy,
+// and a day of staleness is fine for a social card.
+export const PREVIEW_CACHE_CONTROL =
+  "public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400";
+
 const SITE_NAME = "Gakumas Tools";
 const SITE_HOST = new URL(SITE_URL).host;
 

--- a/gakumas-tools/utils/og.js
+++ b/gakumas-tools/utils/og.js
@@ -6,10 +6,6 @@ import { SITE_URL } from "@/utils/localeUrls";
 export const OG_SIZE = { width: 1200, height: 630 };
 export const OG_CONTENT_TYPE = "image/png";
 
-// Query-driven preview images are pure functions of their URL and the
-// bundled data; let browsers and the CDN reuse them instead of re-running
-// satori + resvg for every crawler hit. Data changes ship with a deploy,
-// and a day of staleness is fine for a social card.
 export const PREVIEW_CACHE_CONTROL =
   "public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400";
 


### PR DESCRIPTION
## Problems
1. **Redirect in front of every preview image.** `simulator/page.js` and `dex/tier-list/[type]/page.js` set `openGraph.images` to `/api/preview/?…` and `/api/tier-list-preview/?…` (trailing slash). Next answers those with a 308 to the slash-less URL, so every crawler pays an extra round trip and some scrapers don't follow redirects for images.
2. **Preview images never cached.** `ImageResponse` defaults to `cache-control: public, max-age=0, must-revalidate`, so each crawler/browser hit re-ran satori + resvg (plus `sharp` on icon-cache misses), even though the output is a pure function of the query string and bundled data.
3. **Locale-only OG images rendered per request.** The four `opengraph-image.js` routes depend only on `locale` but were dynamic (`ƒ`) and rendered on every hit.

## Fix
- Drop the trailing slash in both `og:image` URLs (verified: served HTML now points at `/api/preview?stage=1`).
- `PREVIEW_CACHE_CONTROL` (`public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400`) on both preview routes. Data changes ship with a deploy; a day of staleness is acceptable for a social card.
- `export const dynamic = "force-static"` on the four OG image routes. The build now lists them as `○ (Static)`.

## Verified (production build + `next start`)
- `/api/preview?stage=1` and `/api/tier-list-preview?…` → 200 with the new `cache-control`.
- `/api/preview/?stage=1` → 308 (confirms the old URL was redirecting).
- `/en/opengraph-image`, `/ko/calculator/nia/opengraph-image` → 200 `image/png` from the static route.

Context: on production all image routes currently return 502 (Render's proxy fails while streaming the body; not reproducible locally in `next start`, standalone, or the amd64 Docker image, even under a 256 MB cap). Serving the OG images as static content may sidestep that for those four routes; the query-driven previews still need the underlying cause found in Render's logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn