### PR TITLE
Log image render failures instead of aborting the response

### DIFF
--- a/gakumas-tools/app/api/preview/route.js
+++ b/gakumas-tools/app/api/preview/route.js
@@ -1,10 +1,9 @@
-import { ImageResponse } from "next/og";
 import sharp from "sharp";
 import { IdolConfig } from "gakumas-engine";
 import gkImg from "gakumas-images";
 import { PItems, SkillCards } from "gakumas-data";
 import Preview from "@/components/Preview";
-import { PREVIEW_CACHE_CONTROL } from "@/utils/og";
+import { PREVIEW_CACHE_CONTROL, renderImage } from "@/utils/og";
 import { loadoutFromSearchParams } from "@/utils/simulator";
 
 const PNG_CACHE_LIMIT = 500;
@@ -82,7 +81,7 @@ export async function GET(request) {
   );
   const imageMap = Object.fromEntries(entries.filter(([, v]) => v));
 
-  return new ImageResponse(
+  return renderImage(
     (
       <Preview
         itemIds={pItemIds}

--- a/gakumas-tools/app/api/tier-list-preview/route.js
+++ b/gakumas-tools/app/api/tier-list-preview/route.js
@@ -1,6 +1,5 @@
 import { readFile } from "fs/promises";
 import path from "path";
-import { ImageResponse } from "next/og";
 import sharp from "sharp";
 import TierListPreview from "@/components/TierListPreview";
 import {
@@ -17,7 +16,7 @@ import {
   EntityTypes,
   resolveEntityIcon,
 } from "@/utils/entities";
-import { PREVIEW_CACHE_CONTROL } from "@/utils/og";
+import { PREVIEW_CACHE_CONTROL, renderImage } from "@/utils/og";
 import { decodeList, EMPTY_LIST } from "@/utils/tierList";
 
 const PNG_CACHE_LIMIT = 500;
@@ -143,7 +142,7 @@ export async function GET(request) {
     height += rowHeight((list.items[rank] || []).length, columns);
   }
 
-  return new ImageResponse(
+  return renderImage(
     <TierListPreview list={list} rankSrc={rankSrc} itemSrc={itemSrc} />,
     {
       width: PREVIEW_WIDTH,

--- a/gakumas-tools/utils/og.js
+++ b/gakumas-tools/utils/og.js
@@ -13,6 +13,21 @@ export const OG_CONTENT_TYPE = "image/png";
 export const PREVIEW_CACHE_CONTROL =
   "public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400";
 
+// ImageResponse renders inside its body stream, so a satori/resvg failure
+// surfaces as an aborted response that the proxy in front of the app reports
+// as an opaque 502 with nothing in our logs. Render to a buffer first so the
+// error is logged and answered with a real 500.
+export async function renderImage(element, options) {
+  try {
+    const response = new ImageResponse(element, options);
+    const body = await response.arrayBuffer();
+    return new Response(body, { status: 200, headers: response.headers });
+  } catch (err) {
+    console.error("image render failed:", err);
+    return new Response("Image render failed", { status: 500 });
+  }
+}
+
 const SITE_NAME = "Gakumas Tools";
 const SITE_HOST = new URL(SITE_URL).host;
 
@@ -182,7 +197,7 @@ export async function toolOgImage(locale, tool, themeKey = "brand") {
     : (toolMessages.metaTitle ?? toolMessages.title);
   const fontData = await loadFont(locale);
 
-  return new ImageResponse(
+  return renderImage(
     (
       <div
         style={{

--- a/gakumas-tools/utils/og.js
+++ b/gakumas-tools/utils/og.js
@@ -9,10 +9,8 @@ export const OG_CONTENT_TYPE = "image/png";
 export const PREVIEW_CACHE_CONTROL =
   "public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400";
 
-// ImageResponse renders inside its body stream, so a satori/resvg failure
-// surfaces as an aborted response that the proxy in front of the app reports
-// as an opaque 502 with nothing in our logs. Render to a buffer first so the
-// error is logged and answered with a real 500.
+// ImageResponse renders inside its body stream, where a satori/resvg failure
+// would abort an already-started 200 and surface as a bare 502 with no log.
 export async function renderImage(element, options) {
   try {
     const response = new ImageResponse(element, options);


### PR DESCRIPTION
Stacked on #123 (touches the same three files); GitHub will retarget to `master` once that merges.

## Problem
Every image route on production currently returns 502: `/opengraph-image`, `/en/opengraph-image`, `/calculator/*/opengraph-image`, `/api/preview?…`, `/api/tier-list-preview?…`. HTML routes are fine. Observed directly against the Render origin (bypassing Cloudflare): `HEAD` returns 200 `image/png`, `GET` returns Render's own 502 page, occasionally a 200 with a full body after a quiet period. So the handler runs and sets headers, and the failure happens while the body streams.

I could not reproduce it anywhere: `next start`, the standalone server, the arm64 and amd64 Docker images built from a clean `git archive` with the checked-in Dockerfile, and the amd64 image under a 256 MB memory cap all serve every image route correctly (peak ~150 MB). Whatever fails on Render, `ImageResponse` renders inside the body stream, so the exception aborts an already-started 200 response and never reaches the logs.

## Fix
`renderImage(element, options)` in `utils/og.js` awaits `ImageResponse#arrayBuffer()` inside `try/catch` and returns a plain `Response` with the same headers. A failure is now logged with its stack and answered with a real 500 instead of a truncated stream, so the next occurrence will show up in Render's logs. The OG image routes and both preview endpoints use it.

## Verified (production build + `next start`)
- `/en/opengraph-image` → 200, PNG 1200×630.
- `/api/preview?stage=1` → 200, PNG 470×232, cache header intact.
- `/api/tier-list-preview?type=SKILL_CARD&d=…` → 200, PNG 720×192.
- `/api/tier-list-preview?type=NOPE&d=S=1` → 400 (existing validation unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn