### PR TITLE
Add a .dockerignore for the image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# The Dockerfile copies the workspace manifests, gakumas-tools/ and packages/.
+# Everything below is either regenerated inside the image or not needed for
+# the build, and would otherwise be uploaded as build context (host
+# node_modules alone is over a gigabyte) or overlay the container's own
+# installs and build output.
+.git
+**/node_modules
+**/.next
+**/dump
+.env
+.env.*
+**/.env
+**/.env.*
+gk-img
+screenshots
+tests
+scripts
+.venv
+.classifier-data
+**/__pycache__
+**/.DS_Store
+*.log


### PR DESCRIPTION
## Problem
There is no `.dockerignore`, so `docker build .` (the `make build` path, and the GitHub Actions deploy job) sends the entire repository as build context. Locally that includes `node_modules` (~1.1 GB), the `gk-img` submodule, `screenshots/` and `gakumas-tools/dump/`. Because the Dockerfile runs `COPY ./gakumas-tools ./gakumas-tools` after `pnpm install`, a local build also overlays the host's macOS `node_modules`, stale `.next` output and `.env.local` (whose `NEXT_PUBLIC_*` values are inlined by `next build`) on top of the container's clean install.

## Fix
Add a root `.dockerignore` that excludes `node_modules`, `.next`, env files, dumps, the submodule, screenshots, tests, scripts and Python artefacts. The Dockerfile only needs the workspace manifests, `gakumas-tools/` and `packages/`, all of which remain included.

Verified by building the image from a clean `git archive` export (equivalent context) during this session; the resulting image serves the app correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn