### PR TITLE
List dex pages in the sitemap and drop the build-time lastModified

### DIFF
--- a/gakumas-tools/app/sitemap.js
+++ b/gakumas-tools/app/sitemap.js
@@ -22,8 +22,6 @@ const PATHS = [
   "/rehearsal",
 ];
 
-// No lastModified: the sitemap is generated at build time, so a timestamp
-// here would claim every page changed on every deploy.
 export default function sitemap() {
   return PATHS.map((path) => ({
     url: localePath(routing.defaultLocale, path, { absolute: true }),

--- a/gakumas-tools/app/sitemap.js
+++ b/gakumas-tools/app/sitemap.js
@@ -9,16 +9,24 @@ const PATHS = [
   "/calculator/hif",
   "/memory-calculator",
   "/dex",
+  "/dex/reference/skill-cards",
+  "/dex/reference/p-items",
+  "/dex/reference/p-drinks",
+  "/dex/tier-list/skill-cards",
+  "/dex/tier-list/p-items",
+  "/dex/tier-list/p-drinks",
+  "/dex/tier-list/p-idols",
+  "/dex/collection/p-idols",
   "/memories",
   "/simulator",
   "/rehearsal",
 ];
 
+// No lastModified: the sitemap is generated at build time, so a timestamp
+// here would claim every page changed on every deploy.
 export default function sitemap() {
-  const lastModified = new Date();
   return PATHS.map((path) => ({
     url: localePath(routing.defaultLocale, path, { absolute: true }),
-    lastModified,
     priority: path === "/" ? 1.0 : 0.7,
     alternates: { languages: alternateLanguages(path) },
   }));


### PR DESCRIPTION
## Problem
- `app/sitemap.js` set `lastModified = new Date()` when the sitemap was generated (build time), so every deploy told crawlers that every page had just changed. Search engines discount `lastmod` values that are always "now".
- The sitemap omitted the dex reference pages (`/dex/reference/{skill-cards,p-items,p-drinks}`), the tier lists (`/dex/tier-list/{skill-cards,p-items,p-drinks,p-idols}`) and `/dex/collection/p-idols`, all of which are real, indexable routes with their own metadata.

## Fix
Drop `lastModified` and add the eight leaf routes. `/dex/reference`, `/dex/tier-list` and `/dex/collection` are redirects, so they stay out. The generated `sitemap.xml` now has 18 URLs with hreflang alternates and no `lastmod`.

Verified with a production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn