### PR TITLE
Name icon-only controls and give modals dialog semantics

### DIFF
--- a/gakumas-tools/components/EffectEditor/EffectEditor.js
+++ b/gakumas-tools/components/EffectEditor/EffectEditor.js
@@ -20,7 +20,9 @@ function handleKeyDown(e) {
       .match(/^\s*/)[0];
     const extra = value[selectionStart - 1] === "{" ? INDENT : "";
     insertText(`\n${currentIndent}${extra}`);
-  } else if (e.key === "Tab") {
+  } else if (e.key === "Tab" && !e.shiftKey) {
+    // Shift+Tab keeps moving focus backwards so the editor is not a
+    // keyboard trap; plain Tab indents.
     e.preventDefault();
     insertText(INDENT);
   }

--- a/gakumas-tools/components/EffectEditor/EffectEditor.js
+++ b/gakumas-tools/components/EffectEditor/EffectEditor.js
@@ -21,8 +21,7 @@ function handleKeyDown(e) {
     const extra = value[selectionStart - 1] === "{" ? INDENT : "";
     insertText(`\n${currentIndent}${extra}`);
   } else if (e.key === "Tab" && !e.shiftKey) {
-    // Shift+Tab keeps moving focus backwards so the editor is not a
-    // keyboard trap; plain Tab indents.
+    // Shift+Tab has to stay a way out of the textarea.
     e.preventDefault();
     insertText(INDENT);
   }

--- a/gakumas-tools/components/EntityIcon/EntityIcon.js
+++ b/gakumas-tools/components/EntityIcon/EntityIcon.js
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import { useTranslations } from "next-intl";
 import { FaPlus } from "react-icons/fa6";
 import { Idols } from "gakumas-data";
 import Image from "@/components/Image";
@@ -27,6 +28,7 @@ function EntityIcon({
   showTier,
   showEmptyPlaceholder,
 }) {
+  const t = useTranslations("EntityIcon");
   const entity = ENTITY_DATA_BY_TYPE[type].getById(id);
   const icon = resolveEntityIcon(entity, idolId);
 
@@ -84,7 +86,12 @@ function EntityIcon({
 
   if (onClick) {
     return (
-        <button ref={dragRef} className={className} onClick={() => onClick(entity || {})}>
+        <button
+          ref={dragRef}
+          className={className}
+          onClick={() => onClick(entity || {})}
+          aria-label={entity ? undefined : t("emptySlot")}
+        >
           <div ref={dropRef} className={styles.dropArea}>
             {unwrappedElement ||
               (showEmptyPlaceholder && (

--- a/gakumas-tools/components/EntityIcon/EntityIcon.js
+++ b/gakumas-tools/components/EntityIcon/EntityIcon.js
@@ -86,21 +86,18 @@ function EntityIcon({
 
   if (onClick) {
     return (
-        <button
-          ref={dragRef}
-          className={className}
-          onClick={() => onClick(entity || {})}
-          aria-label={entity ? undefined : t("emptySlot")}
-        >
-          <div ref={dropRef} className={styles.dropArea}>
-            {unwrappedElement ||
-              (showEmptyPlaceholder && (
-                <FaPlus
-                  className={styles.emptyPlaceholder}
-                  aria-hidden="true"
-                />
-              ))}
-          </div>
+      <button
+        ref={dragRef}
+        className={className}
+        onClick={() => onClick(entity || {})}
+        aria-label={entity ? undefined : t("emptySlot")}
+      >
+        <div ref={dropRef} className={styles.dropArea}>
+          {unwrappedElement ||
+            (showEmptyPlaceholder && (
+              <FaPlus className={styles.emptyPlaceholder} aria-hidden="true" />
+            ))}
+        </div>
       </button>
     );
   } else {

--- a/gakumas-tools/components/IconButton/IconButton.js
+++ b/gakumas-tools/components/IconButton/IconButton.js
@@ -3,6 +3,8 @@ import { Link } from "@/i18n/routing";
 import c from "@/utils/classNames";
 import styles from "./IconButton.module.scss";
 
+// Icon-only control: `ariaLabel` is the accessible name, since the icon
+// itself carries none.
 function IconButton({
   icon: Icon,
   onClick,
@@ -10,6 +12,7 @@ function IconButton({
   disabled,
   size = "medium",
   tone,
+  ariaLabel,
 }) {
   const className = c(
     styles.iconButton,
@@ -23,14 +26,22 @@ function IconButton({
       className={className}
       href={href}
       target="_blank"
+      rel="noopener noreferrer"
       onClick={onClick}
-      disabled={disabled}
+      aria-disabled={disabled || undefined}
+      aria-label={ariaLabel}
     >
-      <Icon />
+      <Icon aria-hidden="true" />
     </Link>
   ) : (
-    <button className={className} onClick={onClick} disabled={disabled}>
-      <Icon />
+    <button
+      type="button"
+      className={className}
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+    >
+      <Icon aria-hidden="true" />
     </button>
   );
 }

--- a/gakumas-tools/components/IconButton/IconButton.js
+++ b/gakumas-tools/components/IconButton/IconButton.js
@@ -3,8 +3,6 @@ import { Link } from "@/i18n/routing";
 import c from "@/utils/classNames";
 import styles from "./IconButton.module.scss";
 
-// Icon-only control: `ariaLabel` is the accessible name, since the icon
-// itself carries none.
 function IconButton({
   icon: Icon,
   onClick,

--- a/gakumas-tools/components/Memories/MemoriesHeader.js
+++ b/gakumas-tools/components/Memories/MemoriesHeader.js
@@ -51,12 +51,17 @@ function MemoriesHeader({
   return (
     <div className={styles.header}>
       {action ? (
-        <IconButton icon={FaCircleXmark} onClick={() => setAction(null)} />
+        <IconButton
+          icon={FaCircleXmark}
+          onClick={() => setAction(null)}
+          ariaLabel={t("cancel")}
+        />
       ) : (
         <>
           <IconButton
             icon={FaMagnifyingGlass}
             onClick={() => setAction("search")}
+            ariaLabel={t("search")}
           />
           <IconButton
             icon={FaPen}
@@ -64,6 +69,7 @@ function MemoriesHeader({
               setAll({});
               setModal(<MemoryEditorModal />);
             }}
+            ariaLabel={t("create")}
           />
           {status == "authenticated" && (
             <IconButton
@@ -71,12 +77,14 @@ function MemoriesHeader({
               onClick={() =>
                 setModal(<MemoryImporterModal onSuccess={uploadMemories} />)
               }
+              ariaLabel={t("import")}
             />
           )}
           <IconButton
             icon={FaRegTrashCan}
             tone="danger"
             onClick={() => setAction("delete")}
+            ariaLabel={t("delete")}
           />
           <div className={styles.fill} />
           {!memoriesLoading && (

--- a/gakumas-tools/components/Modal/Modal.js
+++ b/gakumas-tools/components/Modal/Modal.js
@@ -1,9 +1,11 @@
 import { memo, useContext, useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { FaXmark } from "react-icons/fa6";
 import ModalContext from "@/contexts/ModalContext";
 import styles from "./Modal.module.scss";
 
 function Modal({ children, dismissable = true, onClose }) {
+  const t = useTranslations("Modal");
   const { closeModal: contextClose, getModalStackDepth } =
     useContext(ModalContext);
   const close = onClose || contextClose;
@@ -86,15 +88,22 @@ function Modal({ children, dismissable = true, onClose }) {
       onMouseDown={handleOverlayMouseDown}
       onMouseUp={handleOverlayMouseUp}
     >
-      <div 
+      <div
         ref={modalRef}
-        className={styles.modal} 
+        className={styles.modal}
         onClick={(e) => e.stopPropagation()}
         tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
       >
         {dismissable && (
-          <button className={styles.close} onClick={close}>
-            <FaXmark />
+          <button
+            type="button"
+            className={styles.close}
+            onClick={close}
+            aria-label={t("close")}
+          >
+            <FaXmark aria-hidden="true" />
           </button>
         )}
         {children}

--- a/gakumas-tools/components/Navbar/NavbarMenu/NavbarMenu.js
+++ b/gakumas-tools/components/Navbar/NavbarMenu/NavbarMenu.js
@@ -70,16 +70,19 @@ function NavbarMenu() {
                 icon={FaXTwitter}
                 href="https://x.com/surisuririsu"
                 size="small"
+                ariaLabel="X"
               />
               <IconButton
                 icon={FaGithub}
                 href="https://github.com/surisuririsu/gakumas-tools"
                 size="small"
+                ariaLabel="GitHub"
               />
               <IconButton
                 icon={SiKofi}
                 href="https://ko-fi.com/surisuririsu"
                 size="small"
+                ariaLabel="Ko-fi"
               />
             </div>
             <div className={styles.fine}>

--- a/gakumas-tools/components/SimulationRuns/ActionIconList.js
+++ b/gakumas-tools/components/SimulationRuns/ActionIconList.js
@@ -4,7 +4,7 @@ import IconButton from "@/components/IconButton";
 function ActionIconList({ items }) {
   return items.map((a) => (
     <span key={a.key} title={a.label}>
-      <IconButton icon={a.icon} onClick={a.onClick} />
+      <IconButton icon={a.icon} onClick={a.onClick} ariaLabel={a.label} />
     </span>
   ));
 }

--- a/gakumas-tools/components/SimulationRuns/ActionsCell.js
+++ b/gakumas-tools/components/SimulationRuns/ActionsCell.js
@@ -1,10 +1,12 @@
 import { memo } from "react";
+import { useTranslations } from "next-intl";
 import { FaEllipsisVertical, FaXmark } from "react-icons/fa6";
 import IconButton from "@/components/IconButton";
 import ActionIconList from "./ActionIconList";
 import styles from "./SimulationRuns.module.scss";
 
 function ActionsCell({ items, menuOpen, onToggle, editMode }) {
+  const t = useTranslations("CompareTab");
   return (
     <div className={styles.actionsCell}>
       <div
@@ -19,6 +21,7 @@ function ActionsCell({ items, menuOpen, onToggle, editMode }) {
           <IconButton
             icon={menuOpen ? FaXmark : FaEllipsisVertical}
             onClick={onToggle}
+            ariaLabel={t("actions")}
           />
         </div>
       )}

--- a/gakumas-tools/messages/en.json
+++ b/gakumas-tools/messages/en.json
@@ -234,6 +234,7 @@
     "filter": "Filter"
   },
   "EntityIcon": {
+    "emptySlot": "Empty slot",
     "high": "H",
     "low": "L",
     "planMismatch": "Plan mismatch",
@@ -339,6 +340,10 @@
   },
   "MemoriesHeader": {
     "selected": "{num} memories selected",
+    "search": "Search",
+    "create": "Create memory",
+    "import": "Import from screenshots",
+    "cancel": "Cancel",
     "delete": "Delete"
   },
   "MemoryImporterModal": {
@@ -433,6 +438,9 @@
     "cancel": "Cancel",
     "ok": "OK"
   },
+  "Modal": {
+    "close": "Close"
+  },
   "SimulatorResult": {
     "min": "Min",
     "average": "Average",
@@ -473,7 +481,8 @@
     "season": "Season",
     "allSeasons": "All seasons",
     "allIdols": "All idols",
-    "allStages": "All stages"
+    "allStages": "All stages",
+    "actions": "Actions"
   },
   "SimulatorStats": {
     "total": "Total",

--- a/gakumas-tools/messages/ja.json
+++ b/gakumas-tools/messages/ja.json
@@ -242,6 +242,7 @@
     "filter": "フィルタ"
   },
   "EntityIcon": {
+    "emptySlot": "空きスロット",
     "high": "高",
     "low": "低",
     "planMismatch": "プラン不一致",
@@ -347,6 +348,10 @@
   },
   "MemoriesHeader": {
     "selected": "{num}個のメモリーを選択",
+    "search": "検索",
+    "create": "メモリーを作成",
+    "import": "スクショから読み込み",
+    "cancel": "キャンセル",
     "delete": "削除する"
   },
   "MemoryImporterModal": {
@@ -441,6 +446,9 @@
     "cancel": "キャンセル",
     "ok": "OK"
   },
+  "Modal": {
+    "close": "閉じる"
+  },
   "SimulatorResult": {
     "min": "最小値",
     "average": "平均値",
@@ -481,7 +489,8 @@
     "season": "シーズン",
     "allSeasons": "全シーズン",
     "allIdols": "全アイドル",
-    "allStages": "全ステージ"
+    "allStages": "全ステージ",
+    "actions": "操作"
   },
   "SimulatorStats": {
     "total": "合計",

--- a/gakumas-tools/messages/ko.json
+++ b/gakumas-tools/messages/ko.json
@@ -234,6 +234,7 @@
     "filter": "필터"
   },
   "EntityIcon": {
+    "emptySlot": "빈 슬롯",
     "high": "고",
     "low": "저",
     "planMismatch": "플랜 불일치",
@@ -339,6 +340,10 @@
   },
   "MemoriesHeader": {
     "selected": "{num}개의 메모리 선택됨",
+    "search": "검색",
+    "create": "메모리 생성",
+    "import": "스크린샷에서 가져오기",
+    "cancel": "취소",
     "delete": "삭제하기"
   },
   "MemoryImporterModal": {
@@ -433,6 +438,9 @@
     "cancel": "취소",
     "ok": "OK"
   },
+  "Modal": {
+    "close": "닫기"
+  },
   "SimulatorResult": {
     "min": "최솟값",
     "average": "평균값",
@@ -473,7 +481,8 @@
     "season": "시즌",
     "allSeasons": "전체 시즌",
     "allIdols": "전체 아이돌",
-    "allStages": "전체 스테이지"
+    "allStages": "전체 스테이지",
+    "actions": "작업"
   },
   "SimulatorStats": {
     "total": "합계",

--- a/gakumas-tools/messages/zh-Hans.json
+++ b/gakumas-tools/messages/zh-Hans.json
@@ -234,6 +234,7 @@
     "filter": "筛选"
   },
   "EntityIcon": {
+    "emptySlot": "空槽位",
     "high": "H",
     "low": "L",
     "planMismatch": "计划不匹配",
@@ -339,6 +340,10 @@
   },
   "MemoriesHeader": {
     "selected": "{num} 个回忆卡被选中",
+    "search": "搜索",
+    "create": "创建回忆卡",
+    "import": "从截图导入",
+    "cancel": "取消",
     "delete": "删除"
   },
   "MemoryImporterModal": {
@@ -433,6 +438,9 @@
     "cancel": "取消",
     "ok": "确认"
   },
+  "Modal": {
+    "close": "关闭"
+  },
   "SimulatorResult": {
     "min": "最低分",
     "average": "平均分",
@@ -473,7 +481,8 @@
     "season": "赛季",
     "allSeasons": "全部赛季",
     "allIdols": "全部偶像",
-    "allStages": "全部舞台"
+    "allStages": "全部舞台",
+    "actions": "操作"
   },
   "SimulatorStats": {
     "total": "合计",


### PR DESCRIPTION
Stacked on #125 (adds a key to the `CompareTab` namespace that the Korean/Chinese files only have after that PR); GitHub will retarget to `master` once it merges.

## Problems
- `IconButton` had no `aria-label`/`title` prop, so all ten usages were announced as "button": search / create / import / delete / cancel in the memories header, the X / GitHub / Ko-fi links, and the load / rename / save / delete actions in loadout history (their `title` was on a wrapper `<span>`, which doesn't name the button). The link variant also passed `disabled` to an `<a>`, which anchors ignore.
- Every `Modal` close button was nameless, and the modal container had no `role="dialog"` / `aria-modal`.
- Empty p-item and skill card slots (`EntityIcon` with no entity) render a `<button>` whose only content is an `aria-hidden` plus icon, so the simulator's and memory editor's slots read as unnamed buttons.
- `EffectEditor` intercepted Shift+Tab as well as Tab, so keyboard users could not leave the textarea backwards (WCAG 2.1.2).

## Fix
- `IconButton` accepts `ariaLabel`, marks the icon `aria-hidden`, uses `aria-disabled` on the link variant and adds `rel="noopener noreferrer"` to its `target="_blank"` links. All usages pass a label.
- `Modal`: `role="dialog"`, `aria-modal="true"`, labelled close button (`Modal.close`).
- `EntityIcon`: empty slots get `aria-label={t("emptySlot")}`; filled slots keep the image `alt`.
- `EffectEditor`: Tab indents, Shift+Tab moves focus.
- New keys in all four locales: `MemoriesHeader.{search,create,import,cancel}`, `CompareTab.actions`, `Modal.close`, `EntityIcon.emptySlot`.

Verified with a production build; no visual changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn