### PR TITLE
Bound the tier-list preview and make it cheap to render

### DIFF
--- a/gakumas-tools/app/api/tier-list-preview/route.js
+++ b/gakumas-tools/app/api/tier-list-preview/route.js
@@ -17,7 +17,15 @@ import {
   resolveEntityIcon,
 } from "@/utils/entities";
 import { PREVIEW_CACHE_CONTROL, renderImage } from "@/utils/og";
-import { decodeList, EMPTY_LIST } from "@/utils/tierList";
+import { clampList, decodeList, EMPTY_LIST } from "@/utils/tierList";
+
+// A social card only needs a summary, and every icon costs render time and
+// wasm memory that is never returned to the OS. Show at most this many per
+// tier; the rest become a "+N" badge.
+const MAX_ITEMS_PER_TIER = 16;
+// The card is rendered at 1x, so icons are embedded at the size they're
+// drawn; the full-size source only inflates the SVG and the wasm heap.
+const ICON_PX = ITEM_SIZE;
 
 const PNG_CACHE_LIMIT = 500;
 const pngCache = new Map();
@@ -34,7 +42,10 @@ async function fetchAsPng(url) {
     const res = await fetch(url);
     if (res.ok) {
       const buf = Buffer.from(await res.arrayBuffer());
-      const png = await sharp(buf).png().toBuffer();
+      const png = await sharp(buf)
+        .resize(ICON_PX, ICON_PX, { fit: "inside", withoutEnlargement: true })
+        .png()
+        .toBuffer();
       dataUrl = `data:image/png;base64,${png.toString("base64")}`;
     }
   } catch (err) {
@@ -104,7 +115,13 @@ export async function GET(request) {
     return new Response("Invalid type", { status: 400 });
   }
 
-  const list = decodeList(url.searchParams.get("d")) || EMPTY_LIST;
+  const list = clampList(
+    decodeList(url.searchParams.get("d")) || EMPTY_LIST,
+    MAX_ITEMS_PER_TIER,
+  );
+  if (!list.tiers.length) {
+    return new Response("No valid tiers", { status: 400 });
+  }
 
   const itemEntries = [];
   for (const rank of list.tiers) {
@@ -118,10 +135,12 @@ export async function GET(request) {
     }
   }
 
+  console.time("tl:fetch");
   const [rankPairs, iconCache] = await Promise.all([
     Promise.all(list.tiers.map(async (r) => [r, await loadRankPng(r)])),
     fetchAll(itemEntries.map(([, key, fetchUrl]) => [key, fetchUrl])),
   ]);
+  console.timeEnd("tl:fetch");
   const rankSrc = Object.fromEntries(rankPairs.filter(([, v]) => v));
 
   const itemSrc = {};
@@ -139,9 +158,11 @@ export async function GET(request) {
 
   let height = PREVIEW_PADDING * 2;
   for (const rank of list.tiers) {
-    height += rowHeight((list.items[rank] || []).length, columns);
+    const count = list.items[rank].length + (list.overflow[rank] ? 1 : 0);
+    height += rowHeight(count, columns);
   }
 
+  console.log("tl:icons", Object.keys(itemSrc).length, "bytes", Object.values(itemSrc).reduce((a, b) => a + b.length, 0));
   return renderImage(
     <TierListPreview list={list} rankSrc={rankSrc} itemSrc={itemSrc} />,
     {

--- a/gakumas-tools/app/api/tier-list-preview/route.js
+++ b/gakumas-tools/app/api/tier-list-preview/route.js
@@ -19,13 +19,7 @@ import {
 import { PREVIEW_CACHE_CONTROL, renderImage } from "@/utils/og";
 import { clampList, decodeList, EMPTY_LIST } from "@/utils/tierList";
 
-// A social card only needs a summary, and every icon costs render time and
-// wasm memory that is never returned to the OS. Show at most this many per
-// tier; the rest become a "+N" badge.
 const MAX_ITEMS_PER_TIER = 16;
-// The card is rendered at 1x, so icons are embedded at the size they're
-// drawn; the full-size source only inflates the SVG and the wasm heap.
-const ICON_PX = ITEM_SIZE;
 
 const PNG_CACHE_LIMIT = 500;
 const pngCache = new Map();
@@ -43,7 +37,7 @@ async function fetchAsPng(url) {
     if (res.ok) {
       const buf = Buffer.from(await res.arrayBuffer());
       const png = await sharp(buf)
-        .resize(ICON_PX, ICON_PX, { fit: "inside", withoutEnlargement: true })
+        .resize(ITEM_SIZE, ITEM_SIZE, { fit: "inside", withoutEnlargement: true })
         .png()
         .toBuffer();
       dataUrl = `data:image/png;base64,${png.toString("base64")}`;
@@ -125,7 +119,7 @@ export async function GET(request) {
 
   const itemEntries = [];
   for (const rank of list.tiers) {
-    for (const id of list.items[rank] || []) {
+    for (const id of list.items[rank]) {
       const entity = ENTITY_DATA.getById(id);
       if (!entity) continue;
       const icon = resolveEntityIcon(entity);
@@ -135,12 +129,10 @@ export async function GET(request) {
     }
   }
 
-  console.time("tl:fetch");
   const [rankPairs, iconCache] = await Promise.all([
     Promise.all(list.tiers.map(async (r) => [r, await loadRankPng(r)])),
     fetchAll(itemEntries.map(([, key, fetchUrl]) => [key, fetchUrl])),
   ]);
-  console.timeEnd("tl:fetch");
   const rankSrc = Object.fromEntries(rankPairs.filter(([, v]) => v));
 
   const itemSrc = {};
@@ -162,7 +154,6 @@ export async function GET(request) {
     height += rowHeight(count, columns);
   }
 
-  console.log("tl:icons", Object.keys(itemSrc).length, "bytes", Object.values(itemSrc).reduce((a, b) => a + b.length, 0));
   return renderImage(
     <TierListPreview list={list} rankSrc={rankSrc} itemSrc={itemSrc} />,
     {

--- a/gakumas-tools/components/TierListPreview/TierListPreview.js
+++ b/gakumas-tools/components/TierListPreview/TierListPreview.js
@@ -5,24 +5,42 @@ export default function TierListPreview({ list, rankSrc, itemSrc }) {
     <div style={styles.container}>
       <div style={styles.panel}>
         {list.tiers.map((rank, i) => {
-          const rowStyle =
-            i === list.tiers.length - 1 ? styles.rowLast : styles.row;
+          const last = i === list.tiers.length - 1;
+          const rowStyle = last ? styles.rowLast : styles.row;
+          const labelStyle = {
+            ...styles.tierLabel,
+            ...(i === 0 && styles.tierLabelFirst),
+            ...(last && styles.tierLabelLast),
+          };
           const ids = list.items[rank] || [];
+          const overflow = list.overflow?.[rank] || 0;
           return (
             <div key={rank} style={rowStyle}>
-              <div style={styles.tierLabel}>
+              <div style={labelStyle}>
                 {rankSrc[rank] && (
                   <img src={rankSrc[rank]} style={styles.rankIcon} />
                 )}
               </div>
               <div style={styles.items}>
                 {ids.map((id) => (
-                  <div key={id} style={styles.item}>
-                    {itemSrc[id] && (
-                      <img src={itemSrc[id]} style={styles.itemImg} />
-                    )}
-                  </div>
+                  // A background image, not <img>: satori's <img> handling
+                  // grows superlinearly with the number of images (256 take
+                  // ~6s vs ~0.07s as backgrounds for the same output). See
+                  // TierListPreview.styles.js for the other render costs.
+                  <div
+                    key={id}
+                    style={
+                      itemSrc[id]
+                        ? { ...styles.item, backgroundImage: `url(${itemSrc[id]})` }
+                        : styles.item
+                    }
+                  />
                 ))}
+                {overflow > 0 && (
+                  <div key="overflow" style={styles.overflow}>
+                    +{overflow}
+                  </div>
+                )}
               </div>
             </div>
           );

--- a/gakumas-tools/components/TierListPreview/TierListPreview.js
+++ b/gakumas-tools/components/TierListPreview/TierListPreview.js
@@ -12,8 +12,8 @@ export default function TierListPreview({ list, rankSrc, itemSrc }) {
             ...(i === 0 && styles.tierLabelFirst),
             ...(last && styles.tierLabelLast),
           };
-          const ids = list.items[rank] || [];
-          const overflow = list.overflow?.[rank] || 0;
+          const ids = list.items[rank];
+          const overflow = list.overflow[rank];
           return (
             <div key={rank} style={rowStyle}>
               <div style={labelStyle}>
@@ -22,25 +22,22 @@ export default function TierListPreview({ list, rankSrc, itemSrc }) {
                 )}
               </div>
               <div style={styles.items}>
+                {/* Backgrounds, not <img>: satori's <img> path is
+                    superlinear in the number of images. */}
                 {ids.map((id) => (
-                  // A background image, not <img>: satori's <img> handling
-                  // grows superlinearly with the number of images (256 take
-                  // ~6s vs ~0.07s as backgrounds for the same output). See
-                  // TierListPreview.styles.js for the other render costs.
                   <div
                     key={id}
                     style={
                       itemSrc[id]
-                        ? { ...styles.item, backgroundImage: `url(${itemSrc[id]})` }
+                        ? {
+                            ...styles.item,
+                            backgroundImage: `url(${itemSrc[id]})`,
+                          }
                         : styles.item
                     }
                   />
                 ))}
-                {overflow > 0 && (
-                  <div key="overflow" style={styles.overflow}>
-                    +{overflow}
-                  </div>
-                )}
+                {overflow > 0 && <div style={styles.overflow}>+{overflow}</div>}
               </div>
             </div>
           );

--- a/gakumas-tools/components/TierListPreview/TierListPreview.styles.js
+++ b/gakumas-tools/components/TierListPreview/TierListPreview.styles.js
@@ -5,6 +5,13 @@ export const ITEM_SIZE = 60;
 export const ITEM_GAP = 6;
 export const ITEMS_PADDING = 10;
 export const MIN_ROW_HEIGHT = 80;
+const PANEL_RADIUS = 10;
+
+// Rendering notes: resvg re-rasterizes a clipped group for every filtered
+// child inside it, so a rounded `overflow: hidden` panel plus an inset
+// box-shadow (an SVG filter) on each tile made a 160-icon list take ~25s.
+// The panel is left unclipped (the first/last tier labels round their own
+// corners) and tiles use a plain border: same look, ~1s.
 
 const styles = {
   container: {
@@ -18,9 +25,8 @@ const styles = {
     display: "flex",
     flexDirection: "column",
     border: "1px solid #dfe2e3",
-    borderRadius: "10px",
+    borderRadius: `${PANEL_RADIUS}px`,
     backgroundColor: "#ffffff",
-    overflow: "hidden",
   },
   row: {
     display: "flex",
@@ -41,6 +47,12 @@ const styles = {
     backgroundColor: "#eef0f1",
     borderRight: "1px solid #dfe2e3",
   },
+  tierLabelFirst: {
+    borderTopLeftRadius: `${PANEL_RADIUS - 1}px`,
+  },
+  tierLabelLast: {
+    borderBottomLeftRadius: `${PANEL_RADIUS - 1}px`,
+  },
   rankIcon: {
     width: "48px",
     height: "48px",
@@ -58,15 +70,23 @@ const styles = {
     width: `${ITEM_SIZE}px`,
     height: `${ITEM_SIZE}px`,
     display: "flex",
-    boxShadow: "inset 0 0 0 2px #ccc",
+    border: "2px solid #ccc",
     borderRadius: "8%",
     backgroundColor: "#eee",
-    overflow: "hidden",
+    backgroundSize: `${ITEM_SIZE}px ${ITEM_SIZE}px`,
+    backgroundRepeat: "no-repeat",
   },
-  itemImg: {
-    width: "100%",
-    height: "100%",
-    objectFit: "cover",
+  overflow: {
+    width: `${ITEM_SIZE}px`,
+    height: `${ITEM_SIZE}px`,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: "8%",
+    backgroundColor: "#eef0f1",
+    color: "#5f6b73",
+    fontSize: "20px",
+    fontWeight: 700,
   },
 };
 

--- a/gakumas-tools/components/TierListPreview/TierListPreview.styles.js
+++ b/gakumas-tools/components/TierListPreview/TierListPreview.styles.js
@@ -7,11 +7,9 @@ export const ITEMS_PADDING = 10;
 export const MIN_ROW_HEIGHT = 80;
 const PANEL_RADIUS = 10;
 
-// Rendering notes: resvg re-rasterizes a clipped group for every filtered
-// child inside it, so a rounded `overflow: hidden` panel plus an inset
-// box-shadow (an SVG filter) on each tile made a 160-icon list take ~25s.
-// The panel is left unclipped (the first/last tier labels round their own
-// corners) and tiles use a plain border: same look, ~1s.
+// resvg re-rasterizes a clipped group for every filtered child, so the panel
+// takes no `overflow: hidden` (the first and last tier labels round their own
+// corners) and the tiles take a border rather than an inset box-shadow.
 
 const styles = {
   container: {

--- a/gakumas-tools/utils/og.js
+++ b/gakumas-tools/utils/og.js
@@ -17,10 +17,19 @@ export const PREVIEW_CACHE_CONTROL =
 // surfaces as an aborted response that the proxy in front of the app reports
 // as an opaque 502 with nothing in our logs. Render to a buffer first so the
 // error is logged and answered with a real 500.
+// resvg refuses anything over 32767px per side, and even well below that a
+// render can take minutes and hundreds of MB. Nothing we generate needs more.
+const MAX_IMAGE_PIXELS = 720 * 4000;
+
 export async function renderImage(element, options) {
+  if (options.width * options.height > MAX_IMAGE_PIXELS) {
+    return new Response("Image too large", { status: 400 });
+  }
   try {
+    console.time("og:render");
     const response = new ImageResponse(element, options);
     const body = await response.arrayBuffer();
+    console.timeEnd("og:render");
     return new Response(body, { status: 200, headers: response.headers });
   } catch (err) {
     console.error("image render failed:", err);

--- a/gakumas-tools/utils/og.js
+++ b/gakumas-tools/utils/og.js
@@ -20,10 +20,8 @@ export async function renderImage(element, options) {
     return new Response("Image too large", { status: 400 });
   }
   try {
-    console.time("og:render");
     const response = new ImageResponse(element, options);
     const body = await response.arrayBuffer();
-    console.timeEnd("og:render");
     return new Response(body, { status: 200, headers: response.headers });
   } catch (err) {
     console.error("image render failed:", err);

--- a/gakumas-tools/utils/tierList.js
+++ b/gakumas-tools/utils/tierList.js
@@ -1,4 +1,4 @@
-import { sortRanks } from "@/components/TierList/ranks";
+import { AVAILABLE_RANKS, sortRanks } from "@/components/TierList/ranks";
 
 export const DEFAULT_RANKS = ["S4", "SSS", "SS", "S", "A", "B"];
 
@@ -32,6 +32,27 @@ export function decodeList(str) {
   }
   if (!tiers.length) return null;
   return { tiers: sortRanks(tiers), items };
+}
+
+// Bound a decoded list for rendering: only known ranks, each id once, and
+// at most `maxPerTier` ids per tier. Returns the clamped list plus how many
+// ids were cut from each tier so the renderer can show an overflow count.
+export function clampList(list, maxPerTier) {
+  const tiers = list.tiers.filter((rank) => AVAILABLE_RANKS.includes(rank));
+  const items = {};
+  const overflow = {};
+  const seen = new Set();
+  for (const rank of tiers) {
+    const unique = [];
+    for (const id of list.items[rank] || []) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      unique.push(id);
+    }
+    items[rank] = unique.slice(0, maxPerTier);
+    overflow[rank] = unique.length - items[rank].length;
+  }
+  return { tiers, items, overflow };
 }
 
 export function isDefaultList(list) {

--- a/gakumas-tools/utils/tierList.js
+++ b/gakumas-tools/utils/tierList.js
@@ -34,9 +34,8 @@ export function decodeList(str) {
   return { tiers: sortRanks(tiers), items };
 }
 
-// Bound a decoded list for rendering: only known ranks, each id once, and
-// at most `maxPerTier` ids per tier. Returns the clamped list plus how many
-// ids were cut from each tier so the renderer can show an overflow count.
+// Known ranks only, each id once, and at most `maxPerTier` ids per tier, plus
+// the count cut from each tier.
 export function clampList(list, maxPerTier) {
   const tiers = list.tiers.filter((rank) => AVAILABLE_RANKS.includes(rank));
   const items = {};


### PR DESCRIPTION
Stacked on #124 → #123. **Suggested merge order: #123, #124, then this.** Together they fix the production 502 on every image route.

## What was happening
Every `ImageResponse` route on gktools.ris.moe (OG images, simulator preview, tier-list preview) returns 502 while HTML keeps working. Sampling production every 20 s after a deploy: images work for ~90 s, then fail continuously until the next deploy/restart.

Reproduced locally with the tier-list preview (`/api/tier-list-preview?type=…&d=…`):

- It accepted any number of tiers and ids (repeats included) and rendered every icon. Its satori/resvg cost was wildly superlinear: **51 icons ≈ 1 s, 255 ≈ 45 s, 432 ≈ 274 s**, with RSS climbing by hundreds of MB per render and never returning (wasm linear memory doesn't shrink).
- An abusive list (17 tiers × 300 ids) produces an SVG over resvg's 32767 px limit; the throw happens inside the response stream, Next logs `⨯ Error: failed to pipe response`, and the client sees a dropped connection, which Render's proxy reports as a bare 502.
- In a 512 MB container that same request OOM-kills the process; a realistic *full* list (all 864 skill cards) simply takes minutes and hundreds of MB.

Shared tier lists are fetched by every crawler/unfurler that sees the link, so one large list poisons the instance until Render restarts it. That matches the observed "works after a deploy, then everything 502s".

## Fixes (each measured)
1. **Clamp the input** (`clampList` in `utils/tierList.js`): known ranks only, each id once, at most `MAX_ITEMS_PER_TIER = 16` per tier with a `+N` badge for the rest. Unknown-rank-only input → 400. `renderImage` also refuses anything over 720×4000 px up front.
2. **Icons as `backgroundImage`, embedded at draw size (60 px).** satori's `<img>` handling is superlinear in image count (256 images: 5.9 s as `<img>`, 0.07 s as backgrounds for identical output); full-size sources only inflated the SVG and wasm heap.
3. **No rounded `overflow: hidden` on the panel, and a real border instead of each tile's inset `box-shadow`.** Bisecting the exact component structure showed resvg re-rasterizes a clipped group for every filtered child: 160 icons took 24.9 s with both, 8.0 s without the shadow, 6.1 s without the clip, 1.0 s without either. First/last tier labels round their own corners so the panel looks the same.

| input | before | after |
|---|---|---|
| all 864 skill cards (17 tiers) | minutes, 600–900 MB | **0.38 s warm / 2.1 s cold**, 720×2152 PNG |
| 5 tiers, 255 cards | 45 s | 0.10 s |
| 17 tiers × 300 repeated ids | dropped connection, 32767 px error | 0.16 s (deduped to 17 icons) |
| unknown ranks / 40 bogus tiers | rendered | 400 |
| 30 consecutive full renders in a 512 MB container | OOM | no failures, peak ~460 MB, back to ~150 MB idle |

The rendered card is visually unchanged apart from the `+N` badge (checked the PNGs).

## Follow-up (not in this PR)
`components/Preview` (the simulator share card) uses the same inset-shadow + `<img>` tiles. It's bounded to 28 icons so it can't take the server down, but it costs ~0.3 s locally per render and would benefit from the same two style changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hc1hs1uFiPhFZjNEW891Sn